### PR TITLE
Fix to eliminate a bunch of -Wmisleading-indentation messages

### DIFF
--- a/include/os/macos/spl/sys/sunddi.h
+++ b/include/os/macos/spl/sys/sunddi.h
@@ -173,8 +173,9 @@ static inline long ddi_fls(long mask) {			\
 	/* Algorithm courtesy of Steve Chessin. */	\
     while (mask) {					\
 		long nx;				\
-		if ((nx = (mask & (mask - 1))) == 0)	\
+		if ((nx = (mask & (mask - 1))) == 0) {	\
 			break;				\
+		}                                       \
 		mask = nx;				\
 	}						\
 	return (ffs(mask));				\


### PR DESCRIPTION
Fix a lot of 

```
./../../../include/os/macos/spl/sys/sunddi.h:178:3: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
```