### PR TITLE
fix client freakout when dataset shared by smb

### DIFF
--- a/cmd/os/macos/InvariantDisks/InvariantDisks/Makefile.am
+++ b/cmd/os/macos/InvariantDisks/InvariantDisks/Makefile.am
@@ -1,6 +1,7 @@
 include $(top_srcdir)/config/Rules.am
 
 AUTOMAKE_OPTIONS = subdir-objects
+AM_LIBTOOLFLAGS += --tag=CXX
 
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include

--- a/module/os/macos/zfs/zfs_vnops_osx.c
+++ b/module/os/macos/zfs/zfs_vnops_osx.c
@@ -3432,7 +3432,11 @@ zfs_vnop_getxattr(struct vnop_getxattr_args *ap)
 				/* Must be 32 bytes */
 				if (resid != sizeof (emptyfinfo) ||
 					size != sizeof (emptyfinfo)) {
-					error = ERANGE;
+					/* The xattr might not be present */
+					if (size == -ENOENT)
+						error = ENOENT;
+					else
+						error = ERANGE;
 					kmem_free(value, resid);
 					goto out;
 				}


### PR DESCRIPTION
This makes Big Sur client smb mounts of shared datasets stop badly misbehaving.

Also sneaking in the missing libtool flags needed to build InvariantDisks without complaint.