### PR TITLE
Make arc sysctl tunables work

### DIFF
--- a/include/os/macos/zfs/sys/kstat_osx.h
+++ b/include/os/macos/zfs/sys/kstat_osx.h
@@ -72,7 +72,8 @@ typedef struct osx_kstat {
 	kstat_named_t zfs_vdev_read_gap_limit;
 	kstat_named_t zfs_vdev_write_gap_limit;
 
-	kstat_named_t arc_lotsfree_percent;
+	kstat_named_t zfs_arc_lotsfree_percent;
+	kstat_named_t zfs_arc_sys_free;
 	kstat_named_t zfs_dirty_data_max;
 	kstat_named_t zfs_delay_max_ns;
 	kstat_named_t zfs_delay_min_dirty_percent;
@@ -243,7 +244,8 @@ extern int zfs_vdev_read_gap_limit;
 extern int zfs_vdev_write_gap_limit;
 
 extern uint_t arc_reduce_dnlc_percent;
-extern int arc_lotsfree_percent;
+extern int zfs_arc_lotsfree_percent;
+extern uint64_t zfs_arc_sys_free;
 extern hrtime_t zfs_delay_max_ns;
 extern int spa_asize_inflation;
 extern unsigned int	zfetch_max_streams;

--- a/module/os/macos/spl/spl-kstat.c
+++ b/module/os/macos/spl/spl-kstat.c
@@ -45,6 +45,8 @@
 void *IOMalloc(vm_size_t size);
 void IOFree(void *address, vm_size_t size);
 
+void *IOMallocAligned(vm_size_t size, vm_offset_t alignment);
+void IOFreeAligned(void *address, vm_size_t size);
 
 /*
  * Statically declared toplevel OID that all kstats
@@ -508,7 +510,7 @@ kstat_handle_raw SYSCTL_HANDLER_ARGS
 	(void) ksp->ks_update(ksp, KSTAT_READ);
 
 	ksp->ks_raw_bufsize = PAGE_SIZE;
-	ksp->ks_raw_buf = IOMalloc(PAGE_SIZE);
+	ksp->ks_raw_buf = IOMallocAligned(PAGE_SIZE, PAGE_SIZE);
 
 	n = 0;
 	has_header = (ksp->ks_raw_ops.headers ||
@@ -549,7 +551,7 @@ restart:
 		}
 		n++;
 	}
-	IOFree(ksp->ks_raw_buf, PAGE_SIZE);
+	IOFreeAligned(ksp->ks_raw_buf, PAGE_SIZE);
 	mutex_exit(ksp->ks_lock);
 	rc = SYSCTL_OUT(req, sbuf_data(sb), sbuf_len(sb));
 	sbuf_delete(sb);

--- a/module/os/macos/zfs/arc_os.c
+++ b/module/os/macos/zfs/arc_os.c
@@ -744,10 +744,22 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 			    ks->arc_zfs_arc_p_min_shift.value.ui64;
 			do_update = B_TRUE;
 		}
-		if(zfs_arc_average_blocksize !=
+		if (zfs_arc_average_blocksize !=
 		    ks->arc_zfs_arc_average_blocksize.value.ui64) {
 			zfs_arc_average_blocksize =
 			    ks->arc_zfs_arc_average_blocksize.value.ui64;
+			do_update = B_TRUE;
+		}
+		if (zfs_arc_lotsfree_percent !=
+		    ks->zfs_arc_lotsfree_percent.value.i64) {
+			zfs_arc_lotsfree_percent =
+			    ks->zfs_arc_lotsfree_percent.value.i64;
+			do_update = B_TRUE;
+		}
+		if (zfs_arc_sys_free !=
+		    ks->zfs_arc_sys_free.value.i64) {
+			zfs_arc_sys_free =
+			    ks->zfs_arc_sys_free.value.i64;
 			do_update = B_TRUE;
 		}
 
@@ -767,6 +779,10 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 		ks->arc_zfs_arc_p_min_shift.value.ui64 = zfs_arc_p_min_shift;
 		ks->arc_zfs_arc_average_blocksize.value.ui64 =
 		    zfs_arc_average_blocksize;
+		ks->zfs_arc_lotsfree_percent.value.i64 =
+		    zfs_arc_lotsfree_percent;
+		ks->zfs_arc_sys_free.value.i64 =
+		    zfs_arc_sys_free;
 	}
 	return (0);
 }

--- a/module/os/macos/zfs/arc_os.c
+++ b/module/os/macos/zfs/arc_os.c
@@ -704,45 +704,14 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 
 		/* Did we change the value ? */
 		if (ks->arc_zfs_arc_max.value.ui64 != zfs_arc_max) {
-
 			/* Assign new value */
 			zfs_arc_max = ks->arc_zfs_arc_max.value.ui64;
 			do_update = B_TRUE;
-
-			/* Update ARC with new value */
-			if (zfs_arc_max > 64<<20 && zfs_arc_max <
-			    physmem * PAGESIZE)
-				arc_c_max = zfs_arc_max;
-
-			arc_c = arc_c_max;
-			arc_p = (arc_c >> 1);
-
-			/* If meta_limit is not set, adjust it automatically */
-			if (!zfs_arc_meta_limit)
-				arc_meta_limit = arc_c_max / 4;
 		}
 
 		if (ks->arc_zfs_arc_min.value.ui64 != zfs_arc_min) {
 			zfs_arc_min = ks->arc_zfs_arc_min.value.ui64;
 			do_update = B_TRUE;
-			if (zfs_arc_min > 64<<20 && zfs_arc_min <= arc_c_max) {
-				arc_c_min = zfs_arc_min;
-				printf("ZFS: set arc_c_min %llu, arc_meta_min "
-				    "%llu, zfs_arc_meta_min %llu\n",
-				    arc_c_min, arc_meta_min, zfs_arc_meta_min);
-				if (arc_c < arc_c_min) {
-					printf("ZFS: raise arc_c %llu to "
-					    "arc_c_min %llu\n", arc_c,
-					    arc_c_min);
-					arc_c = arc_c_min;
-					if (arc_p < (arc_c >> 1)) {
-						printf("ZFS: raise arc_p %llu "
-						    "to %llu\n",
-						    arc_p, (arc_c >> 1));
-						arc_p = (arc_c >> 1);
-					}
-				}
-			}
 		}
 
 		if (ks->arc_zfs_arc_meta_limit.value.ui64 !=
@@ -750,57 +719,36 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 			zfs_arc_meta_limit =
 			    ks->arc_zfs_arc_meta_limit.value.ui64;
 			do_update = B_TRUE;
-			/* Allow the tunable to override if it is reasonable */
-			if (zfs_arc_meta_limit > 0 &&
-			    zfs_arc_meta_limit <= arc_c_max)
-				arc_meta_limit = zfs_arc_meta_limit;
-
-			if (arc_c_min < arc_meta_limit / 2 &&
-			    zfs_arc_min == 0)
-				arc_c_min = arc_meta_limit / 2;
-
-			printf("ZFS: set arc_meta_limit %llu, arc_c_min %llu,"
-			    "zfs_arc_meta_limit %lu\n",
-			    arc_meta_limit, arc_c_min, zfs_arc_meta_limit);
 		}
 
 		if (ks->arc_zfs_arc_meta_min.value.ui64 != zfs_arc_meta_min) {
 			zfs_arc_meta_min  = ks->arc_zfs_arc_meta_min.value.ui64;
 			do_update = B_TRUE;
-			if (zfs_arc_meta_min >= arc_c_min) {
-				printf("ZFS: probable error, zfs_arc_meta_min "
-				    "%llu >= arc_c_min %llu\n",
-				    zfs_arc_meta_min, arc_c_min);
-			}
-			if (zfs_arc_meta_min > 0 &&
-			    zfs_arc_meta_min <= arc_meta_limit)
-				arc_meta_min = zfs_arc_meta_min;
-			printf("ZFS: set arc_meta_min %llu\n", arc_meta_min);
 		}
 
 		if (zfs_arc_grow_retry !=
 		    ks->arc_zfs_arc_grow_retry.value.ui64) {
 			zfs_arc_grow_retry =
 			    ks->arc_zfs_arc_grow_retry.value.ui64;
-			do_update = 1;
+			do_update = B_TRUE;
 		}
 		if (zfs_arc_shrink_shift !=
 		    ks->arc_zfs_arc_shrink_shift.value.ui64) {
 			zfs_arc_shrink_shift =
 			    ks->arc_zfs_arc_shrink_shift.value.ui64;
-			do_update = 1;
+			do_update = B_TRUE;
 		}
 		if (zfs_arc_p_min_shift !=
 		    ks->arc_zfs_arc_p_min_shift.value.ui64) {
 			zfs_arc_p_min_shift =
 			    ks->arc_zfs_arc_p_min_shift.value.ui64;
-			do_update = 1;
+			do_update = B_TRUE;
 		}
 		if(zfs_arc_average_blocksize !=
 		    ks->arc_zfs_arc_average_blocksize.value.ui64) {
 			zfs_arc_average_blocksize =
 			    ks->arc_zfs_arc_average_blocksize.value.ui64;
-			do_update = 1;
+			do_update = B_TRUE;
 		}
 
 		if (do_update)

--- a/module/os/macos/zfs/arc_os.c
+++ b/module/os/macos/zfs/arc_os.c
@@ -698,6 +698,7 @@ int
 arc_kstat_update_osx(kstat_t *ksp, int rw)
 {
 	osx_kstat_t *ks = ksp->ks_data;
+	boolean_t do_update = B_FALSE;
 
 	if (rw == KSTAT_WRITE) {
 
@@ -706,6 +707,7 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 
 			/* Assign new value */
 			zfs_arc_max = ks->arc_zfs_arc_max.value.ui64;
+			do_update = B_TRUE;
 
 			/* Update ARC with new value */
 			if (zfs_arc_max > 64<<20 && zfs_arc_max <
@@ -722,6 +724,7 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 
 		if (ks->arc_zfs_arc_min.value.ui64 != zfs_arc_min) {
 			zfs_arc_min = ks->arc_zfs_arc_min.value.ui64;
+			do_update = B_TRUE;
 			if (zfs_arc_min > 64<<20 && zfs_arc_min <= arc_c_max) {
 				arc_c_min = zfs_arc_min;
 				printf("ZFS: set arc_c_min %llu, arc_meta_min "
@@ -746,7 +749,7 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 		    zfs_arc_meta_limit) {
 			zfs_arc_meta_limit =
 			    ks->arc_zfs_arc_meta_limit.value.ui64;
-
+			do_update = B_TRUE;
 			/* Allow the tunable to override if it is reasonable */
 			if (zfs_arc_meta_limit > 0 &&
 			    zfs_arc_meta_limit <= arc_c_max)
@@ -763,6 +766,7 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 
 		if (ks->arc_zfs_arc_meta_min.value.ui64 != zfs_arc_meta_min) {
 			zfs_arc_meta_min  = ks->arc_zfs_arc_meta_min.value.ui64;
+			do_update = B_TRUE;
 			if (zfs_arc_meta_min >= arc_c_min) {
 				printf("ZFS: probable error, zfs_arc_meta_min "
 				    "%llu >= arc_c_min %llu\n",
@@ -774,13 +778,33 @@ arc_kstat_update_osx(kstat_t *ksp, int rw)
 			printf("ZFS: set arc_meta_min %llu\n", arc_meta_min);
 		}
 
-		zfs_arc_grow_retry = ks->arc_zfs_arc_grow_retry.value.ui64;
-		arc_grow_retry = zfs_arc_grow_retry;
-		zfs_arc_shrink_shift = ks->arc_zfs_arc_shrink_shift.value.ui64;
-		zfs_arc_p_min_shift = ks->arc_zfs_arc_p_min_shift.value.ui64;
-		zfs_arc_average_blocksize =
-		    ks->arc_zfs_arc_average_blocksize.value.ui64;
+		if (zfs_arc_grow_retry !=
+		    ks->arc_zfs_arc_grow_retry.value.ui64) {
+			zfs_arc_grow_retry =
+			    ks->arc_zfs_arc_grow_retry.value.ui64;
+			do_update = 1;
+		}
+		if (zfs_arc_shrink_shift !=
+		    ks->arc_zfs_arc_shrink_shift.value.ui64) {
+			zfs_arc_shrink_shift =
+			    ks->arc_zfs_arc_shrink_shift.value.ui64;
+			do_update = 1;
+		}
+		if (zfs_arc_p_min_shift !=
+		    ks->arc_zfs_arc_p_min_shift.value.ui64) {
+			zfs_arc_p_min_shift =
+			    ks->arc_zfs_arc_p_min_shift.value.ui64;
+			do_update = 1;
+		}
+		if(zfs_arc_average_blocksize !=
+		    ks->arc_zfs_arc_average_blocksize.value.ui64) {
+			zfs_arc_average_blocksize =
+			    ks->arc_zfs_arc_average_blocksize.value.ui64;
+			do_update = 1;
+		}
 
+		if (do_update)
+			arc_tuning_update(B_TRUE);
 	} else {
 
 		ks->arc_zfs_arc_max.value.ui64 = zfs_arc_max;

--- a/module/os/macos/zfs/zfs_kstat_osx.c
+++ b/module/os/macos/zfs/zfs_kstat_osx.c
@@ -269,6 +269,9 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 		zfs_vfs_sync_paranoia =
 		    ks->darwin_use_system_sync.value.ui64;
 
+		/* ARC */
+		arc_kstat_update_osx(ksp, rw);
+
 		/* L2ARC */
 		l2arc_write_max = ks->l2arc_write_max.value.ui64;
 		l2arc_write_boost = ks->l2arc_write_boost.value.ui64;
@@ -580,6 +583,9 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 		ks->darwin_skip_unlinked_drain.value.ui64 =
 		    zfs_vnop_skip_unlinked_drain;
 		ks->darwin_use_system_sync.value.ui64 = zfs_vfs_sync_paranoia;
+
+		/* ARC */
+		arc_kstat_update_osx(ksp, rw);
 
 		/* L2ARC */
 		ks->l2arc_write_max.value.ui64 = l2arc_write_max;

--- a/module/os/macos/zfs/zfs_kstat_osx.c
+++ b/module/os/macos/zfs/zfs_kstat_osx.c
@@ -106,7 +106,7 @@ osx_kstat_t osx_kstat = {
 	{ "write_gap_limit",			KSTAT_DATA_INT64  },
 
 	{"zfs_arc_lotsfree_percent",		KSTAT_DATA_INT64  },
-	{"zfs_arc_sys_free",		        KSTAT_DATA_INT64  },
+	{"zfs_arc_sys_free",			KSTAT_DATA_INT64  },
 	{"zfs_dirty_data_max",			KSTAT_DATA_INT64  },
 	{"zfs_delay_max_ns",			KSTAT_DATA_INT64  },
 	{"zfs_delay_min_dirty_percent",		KSTAT_DATA_INT64  },

--- a/module/os/macos/zfs/zfs_kstat_osx.c
+++ b/module/os/macos/zfs/zfs_kstat_osx.c
@@ -105,7 +105,8 @@ osx_kstat_t osx_kstat = {
 	{ "read_gap_limit",			KSTAT_DATA_INT64  },
 	{ "write_gap_limit",			KSTAT_DATA_INT64  },
 
-	{"arc_lotsfree_percent",		KSTAT_DATA_INT64  },
+	{"zfs_arc_lotsfree_percent",		KSTAT_DATA_INT64  },
+	{"zfs_arc_sys_free",		        KSTAT_DATA_INT64  },
 	{"zfs_dirty_data_max",			KSTAT_DATA_INT64  },
 	{"zfs_delay_max_ns",			KSTAT_DATA_INT64  },
 	{"zfs_delay_min_dirty_percent",		KSTAT_DATA_INT64  },
@@ -319,8 +320,6 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 		zfs_vdev_write_gap_limit =
 		    ks->zfs_vdev_write_gap_limit.value.i64;
 
-		arc_lotsfree_percent =
-		    ks->arc_lotsfree_percent.value.i64;
 		zfs_dirty_data_max =
 		    ks->zfs_dirty_data_max.value.i64;
 		zfs_delay_max_ns =
@@ -633,8 +632,6 @@ static int osx_kstat_update(kstat_t *ksp, int rw)
 		ks->zfs_vdev_write_gap_limit.value.i64 =
 		    zfs_vdev_write_gap_limit;
 
-		ks->arc_lotsfree_percent.value.i64 =
-		    arc_lotsfree_percent;
 		ks->zfs_dirty_data_max.value.i64 =
 		    zfs_dirty_data_max;
 		ks->zfs_delay_max_ns.value.i64 =


### PR DESCRIPTION
We weren't listening to arc sysctls after removing arc_kstat_update_osx().

Restore that.

Also use upstream's sanity-checking function arc_tuning_update().
