### PR TITLE
fix the direction of a uio_move

### DIFF
--- a/module/os/macos/zfs/zfs_vnops_osx.c
+++ b/module/os/macos/zfs/zfs_vnops_osx.c
@@ -3597,7 +3597,7 @@ zfs_vnop_setxattr(struct vnop_setxattr_args *ap)
 	int  error = 0;
 	znode_t *xdzp = NULL;
 
-	printf("+setxattr vp %p '%s' (enabled: %d) resid %lu\n", ap->a_vp,
+	dprintf("+setxattr vp %p '%s' (enabled: %d) resid %lu\n", ap->a_vp,
 		ap->a_name, zfsvfs->z_xattr, zfs_uio_resid(uio));
 
 	/* xattrs disabled? */


### PR DESCRIPTION
    "xattr -l <file>" would return inconsistent garbage,
    especially from non-com.apple.FinderInfo xattrs.

    The UIO_WRITE was a 0 (UIO_READ) in the previous commit, change it.

    Also turn kmem_alloc -> kmem_zalloc in zfs_vnops_osx.c,
    for cheap extra safety.