### PR TITLE
Memory fixes on macOS_pure

### DIFF
--- a/include/os/macos/spl/sys/seg_kmem.h
+++ b/include/os/macos/spl/sys/seg_kmem.h
@@ -41,12 +41,8 @@ extern "C" {
 
 extern uint64_t segkmem_total_allocated;
 
-/* qcaching for zio arenas and abd arena */
-extern vmem_t *zio_arena_parent;
-/* arena for zio caches for file blocks */
-extern vmem_t *zio_arena;
-/* arena for zio caches for (zfs) metadata blocks */
-extern vmem_t *zio_metadata_arena;
+/* qcaching for abd */
+extern vmem_t *abd_arena;
 
 /*
  * segkmem page vnodes
@@ -63,10 +59,8 @@ extern void segkmem_free(vmem_t *, void *, size_t);
 extern void kernelheap_init(void);
 extern void kernelheap_fini(void);
 
-extern void *segkmem_zio_alloc(vmem_t *, size_t, int);
-extern void segkmem_zio_free(vmem_t *, void *, size_t);
-extern void segkmem_zio_init(void);
-extern void segkmem_zio_fini(void);
+extern void segkmem_abd_init(void);
+extern void segkmem_abd_fini(void);
 
 /*
  * Flags for segkmem_xalloc().

--- a/include/os/macos/spl/sys/sysmacros.h
+++ b/include/os/macos/spl/sys/sysmacros.h
@@ -28,6 +28,8 @@
 #ifndef _SPL_SYSMACROS_H
 #define	_SPL_SYSMACROS_H
 
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
 #include <sys/types.h>
 #include <string.h>
 #include <sys/varargs.h>

--- a/module/os/macos/spl/spl-kstat.c
+++ b/module/os/macos/spl/spl-kstat.c
@@ -711,6 +711,10 @@ kstat_handle_string SYSCTL_HANDLER_ARGS
 
 			inbuf[req->newlen] = 0;
 
+			/*
+			 * Copy the new value from user space
+			 * (copyin done by XNU)
+			 */
 			kstat_named_setstr(named, (const char *)inbuf);
 
 			/* and invoke the update operation: last call out */

--- a/module/os/macos/spl/spl-seg_kmem.c
+++ b/module/os/macos/spl/spl-seg_kmem.c
@@ -133,14 +133,8 @@ uint64_t segkmem_total_mem_allocated = 0;
 /* primary kernel heap arena */
 vmem_t *heap_arena;
 
-/* qcaches for zio and abd arenas */
-vmem_t *zio_arena_parent;
-
-/* arena for allocating file data */
-vmem_t *zio_arena;
-
-/* and for allocation of zfs metadata */
-vmem_t *zio_metadata_arena;
+/* qcaches abd */
+vmem_t *abd_arena;
 
 #ifdef _KERNEL
 extern uint64_t total_memory;
@@ -259,57 +253,30 @@ segkmem_free(vmem_t *vmp, void *inaddr, size_t size)
 // smd: we nevertheless plumb in an arena with heap as parent, so that
 // we can track stats and maintain the VM_ / qc settings differently
 void
-segkmem_zio_init()
+segkmem_abd_init()
 {
-	// note:  from startup.c and vm_machparam: SEGZIOMINSIZE = 512M.
-	// and SEGZSIOMAXSIZE = 512G; if physmem is between the two, then
-	// segziosize is (physmem - SEGZIOMAXSIZE) / 2.
-
-	// Illumos does not segregate zio_metadata_arena out of heap,
-	// almost exclusively for reasons involving panic dump data
-	// retention. However, parenting zio_metadata_arena to
-	// spl_root_arena and giving it its own qcaches provides better
-	// kstat observability *and* noticeably better performance in
-	// realworld (zfs/dmu) metadata-heavy activity.    Additionally,
-	// the qcaches pester spl_heap_arena only for slabs 256k and bigger,
-	// and each of the qcache entries (powers of two from PAGESIZE to
-	// 64k) are *exact-fit* and therefore dramatically reduce internal
-	// fragmentation and more than pay off for the extra code and (tiny)
-	// extra data for holding the arenas' segment tables.
+	/*
+	 * OpenZFS does not segregate the abd kmem cache out of the general
+	 * heap, leading to large numbers of short-lived slabs exchanged
+	 * between the kmem cache and it's parent.  XNU absorbs this with a
+	 * qcache, following its history of absorbing the pre-ABD zio file and
+	 * metadata caches being qcached (which raises the exchanges with the
+	 * general heap from PAGESIZE to 256k).
+	 */
 
 	extern vmem_t *spl_heap_arena;
 
-	zio_arena_parent = vmem_create("zfs_qcache", NULL, 0,
+	abd_arena = vmem_create("abd_cache", NULL, 0,
 	    PAGESIZE, vmem_alloc, vmem_free, spl_heap_arena,
-	    16 * 1024, VM_SLEEP | VMC_TIMEFREE);
+	    262144, VM_SLEEP | VMC_NO_QCACHE);
 
-	ASSERT(zio_arena_parent != NULL);
-
-	zio_arena = vmem_create("zfs_file_data", NULL, 0,
-	    PAGESIZE, vmem_alloc, vmem_free, zio_arena_parent,
-	    0, VM_SLEEP);
-
-	zio_metadata_arena = vmem_create("zfs_metadata", NULL, 0,
-	    PAGESIZE, vmem_alloc, vmem_free, zio_arena_parent,
-	    0, VM_SLEEP);
-
-	ASSERT(zio_arena != NULL);
-	ASSERT(zio_metadata_arena != NULL);
-
-	extern void spl_zio_no_grow_init(void);
-	spl_zio_no_grow_init();
+	ASSERT(abd_arena != NULL);
 }
 
 void
-segkmem_zio_fini(void)
+segkmem_abd_fini(void)
 {
-	if (zio_arena) {
-		vmem_destroy(zio_arena);
-	}
-	if (zio_metadata_arena) {
-		vmem_destroy(zio_metadata_arena);
-	}
-	if (zio_arena_parent) {
-		vmem_destroy(zio_arena_parent);
+	if (abd_arena) {
+		vmem_destroy(abd_arena);
 	}
 }

--- a/module/os/macos/spl/spl-vmem.c
+++ b/module/os/macos/spl/spl-vmem.c
@@ -3440,7 +3440,7 @@ vmem_init(const char *heap_name,
 	spl_heap_arena_initial_alloc_size = resv_size;
 
 	// kstat.vmem.vmem.heap : kmem_cache_alloc() and similar calls
-	// to handle in-memory datastructures other than arc and zio buffers.
+	// to handle in-memory datastructures other than abd
 
 	heap = vmem_create(heap_name,  // id 16
 	    NULL, 0, heap_quantum,
@@ -3856,10 +3856,7 @@ spl_arc_no_grow_impl(const uint16_t b, const size_t size,
 		spl_arc_no_grow_bits &= ~b_bit;
 	}
 
-	extern bool spl_zio_is_suppressed(const size_t, const uint64_t,
-	    const boolean_t, kmem_cache_t **);
-
-	return (spl_zio_is_suppressed(size, now, buf_is_metadata, kc));
+	return (false);
 }
 
 static inline uint16_t

--- a/module/os/macos/spl/spl-vnode.c
+++ b/module/os/macos/spl/spl-vnode.c
@@ -26,6 +26,7 @@
  *
  */
 
+#include <sys/sysmacros.h>
 #include <sys/vnode.h>
 #include <sys/debug.h>
 #include <sys/malloc.h>

--- a/module/os/macos/zfs/abd_os.c
+++ b/module/os/macos/zfs/abd_os.c
@@ -260,7 +260,7 @@ void
 abd_init(void)
 {
 	abd_chunk_cache = kmem_cache_create("abd_chunk", zfs_abd_chunk_size, 0,
-	    NULL, NULL, NULL, NULL, 0, KMC_NOTOUCH | KMC_NODEBUG);
+	    NULL, NULL, NULL, NULL, abd_arena, KMC_NOTOUCH);
 
 	abd_ksp = kstat_create("zfs", 0, "abdstats", "misc", KSTAT_TYPE_NAMED,
 	    sizeof (abd_stats) / sizeof (kstat_named_t), KSTAT_FLAG_VIRTUAL);

--- a/module/os/macos/zfs/arc_os.c
+++ b/module/os/macos/zfs/arc_os.c
@@ -244,6 +244,7 @@ static void arc_kmem_reap_now(void)
 	/* arc.c will do the heavy lifting */
 	arc_kmem_reap_soon();
 
+#if 0
 	/* Now some OsX additionals */
 	extern kmem_cache_t *abd_chunk_cache;
 	extern kmem_cache_t *znode_cache;
@@ -251,13 +252,14 @@ static void arc_kmem_reap_now(void)
 	kmem_cache_reap_now(abd_chunk_cache);
 	if (znode_cache) kmem_cache_reap_now(znode_cache);
 
-	if (zio_arena_parent != NULL) {
+	if (abd_arena != NULL) {
 		/*
 		 * Ask the vmem arena to reclaim unused memory from its
 		 * quantum caches.
 		 */
-		vmem_qcache_reap(zio_arena_parent);
+		vmem_qcache_reap(abd_arena);
 	}
+#endif
 }
 
 
@@ -440,10 +442,10 @@ arc_reclaim_thread(void *unused)
 				// 2 * SPA_MAXBLOCKSIZE
 				const int64_t large_amount =
 				    32LL * 1024LL * 1024LL;
+#if 0 // very noisy
 				const int64_t huge_amount =
 				    128LL * 1024LL * 1024LL;
 
-#if 0 // very noisy
 				if (to_free > large_amount ||
 				    evicted > huge_amount)
 					dprintf("SPL: %s: post-reap %lld "
@@ -490,13 +492,6 @@ arc_reclaim_thread(void *unused)
 				// this point, try to give memory back to
 				// lower arenas (and possibly xnu).
 
-				int64_t total_freed =
-				    arc_shrink_freed + evicted;
-				if (total_freed >= huge_amount) {
-					if (zio_arena_parent != NULL)
-						vmem_qcache_reap(
-						    zio_arena_parent);
-				}
 				if (arc_shrink_freed > 0)
 					evicted += arc_shrink_freed;
 			} else if (old_to_free > 0) {


### PR DESCRIPTION
Remove a lot of obsolete code, make things happier in the face of very busy ABD alloc/free, and some minor additional memory-related changes, all squashed and cstyled.

Plus an additional commit to get it to build with finicky modern compiler.