### PR TITLE
[wip] Taskq threadpri on mac os pure

### DIFF
--- a/include/os/macos/spl/sys/sysmacros.h
+++ b/include/os/macos/spl/sys/sysmacros.h
@@ -109,16 +109,13 @@ extern unsigned int max_ncpus;
 /*
  * In OSX, the kernel thread priorities start at 81 and goes to
  * 95 MAXPRI_KERNEL. BASEPRI_REALTIME starts from 96. Since
- * swap priority is at 92. Most ZFS priorities should probably
- * stay below this, but kmem_reap needs to be higher.
+ * swap priority is at 92.  ZFS priorities should have a base below
+ * 81 in general.  Xnu will dynamically adjust priorities of
+ * some taskq threads around maxclsyspri.
  */
-#define	minclsyspri  81 /* BASEPRI_KERNEL */
-#define	defclsyspri  81 /* BASEPRI_KERNEL */
-#define	maxclsyspri  95
-
-
-#define	NICE_TO_PRIO(nice)		(MAX_RT_PRIO + (nice) + 20)
-#define	PRIO_TO_NICE(prio)		((prio) - MAX_RT_PRIO - 20)
+#define	minclsyspri  70 /* well below the render server and other graphics */
+#define	defclsyspri  75 /* five below the xnu kernel services */
+#define	maxclsyspri  80 /* 1 less than base, 2 less than networking */
 
 /*
  * Missing macros

--- a/include/os/macos/spl/sys/taskq.h
+++ b/include/os/macos/spl/sys/taskq.h
@@ -58,6 +58,11 @@ struct taskq_ent;
 #define	TASKQ_THREADS_CPU_PCT	0x0008	/* number of threads as % of ncpu */
 #define	TASKQ_DC_BATCH		0x0010	/* Taskq uses SDC in batch mode */
 
+#ifdef __APPLE__
+#define	TASKQ_TIMESHARE		0x0020  /* macOS dynamic thread priority */
+#define	TASKQ_REALLY_DYNAMIC	0x0040  /* don't filter out TASKQ_DYNAMIC */
+#endif
+
 /*
  * Flags for taskq_dispatch. TQ_SLEEP/TQ_NOSLEEP should be same as
  * KM_SLEEP/KM_NOSLEEP.

--- a/include/os/macos/spl/sys/thread.h
+++ b/include/os/macos/spl/sys/thread.h
@@ -34,6 +34,7 @@
 #include <sys/tsd.h>
 #include <sys/condvar.h>
 #include <kern/sched_prim.h>
+#include <mach/thread_policy.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -75,20 +76,23 @@ typedef void (*thread_func_t)(void *);
 #ifdef SPL_DEBUG_THREAD
 
 #define	thread_create(A, B, C, D, E, F, G, H) \
-    spl_thread_create(A, B, C, D, E, G, __FILE__, __LINE__, H)
+    spl_thread_create_named(__FILE__, A, B, C, D, E, G, __FILE__, __LINE__, H)
 #define	thread_create_named(name, A, B, C, D, E, F, G, H)	\
-    spl_thread_create(A, B, C, D, E, G, __FILE__, __LINE__, H)
-extern kthread_t *spl_thread_create(caddr_t stk, size_t stksize,
+    spl_thread_create_named(name, A, B, C, D, E, G, __FILE__, __LINE__, H)
+
+extern kthread_t *spl_thread_create_named(char *name,
+    caddr_t stk, size_t stksize,
     void (*proc)(void *), void *arg, size_t len, /* proc_t *pp, */ int state,
     char *, int, pri_t pri);
 
 #else
 
 #define	thread_create(A, B, C, D, E, F, G, H) \
-    spl_thread_create(A, B, C, D, E, G, H)
+    spl_thread_create_named(__FILE__, A, B, C, D, E, G, H)
 #define	thread_create_named(name, A, B, C, D, E, F, G, H)	\
-    spl_thread_create(A, B, C, D, E, G, H)
-extern kthread_t *spl_thread_create(caddr_t stk, size_t stksize,
+    spl_thread_create_named(name, A, B, C, D, E, G, H)
+extern kthread_t *spl_thread_create_named(char *name,
+    caddr_t stk, size_t stksize,
     void (*proc)(void *), void *arg, size_t len, /* proc_t *pp, */ int state,
     pri_t pri);
 
@@ -98,6 +102,23 @@ extern kthread_t *spl_thread_create(caddr_t stk, size_t stksize,
 extern void spl_thread_exit(void);
 
 extern kthread_t *spl_current_thread(void);
+
+extern void set_thread_importance_named(thread_t, pri_t, char *);
+extern void set_thread_importance(thread_t, pri_t);
+
+extern void set_thread_throughput_named(thread_t,
+    thread_throughput_qos_t, char *);
+extern void set_thread_throughput(thread_t,
+    thread_throughput_qos_t);
+
+extern void set_thread_latency_named(thread_t,
+    thread_latency_qos_t, char *);
+extern void set_thread_latency(thread_t,
+    thread_latency_qos_t);
+
+extern void set_thread_timeshare_named(thread_t,
+    char *);
+extern void set_thread_timeshare(thread_t);
 
 #define	delay osx_delay
 extern void osx_delay(int);

--- a/module/os/macos/spl/spl-thread.c
+++ b/module/os/macos/spl/spl-thread.c
@@ -38,19 +38,19 @@
 uint64_t zfs_threads = 0;
 
 kthread_t *
-spl_thread_create(
-	caddr_t stk,
-	size_t stksize,
-	void (*proc)(void *),
-	void *arg,
-	size_t len,
-	/* struct proc *pp, */
-	int state,
+spl_thread_create_named(
+    char *name,
+    caddr_t stk,
+    size_t stksize,
+    void (*proc)(void *),
+    void *arg,
+    size_t len,
+    int state,
 #ifdef SPL_DEBUG_THREAD
-	char *filename,
-	int line,
+    char *filename,
+    int line,
 #endif
-	pri_t pri)
+    pri_t pri)
 {
 	kern_return_t result;
 	thread_t thread;
@@ -65,45 +65,12 @@ spl_thread_create(
 	if (result != KERN_SUCCESS)
 		return (NULL);
 
-	/* Improve the priority when asked to do so */
-	if (pri > minclsyspri) {
-		thread_precedence_policy_data_t policy;
+	set_thread_importance_named(thread, pri, "anonymous new zfs thread");
 
-		/*
-		 * kernel priorities (osfmk/kern/sched.h)
-		 *
-		 * 96           Reserved (real-time)
-		 * 95           Kernel mode only
-		 *                              A
-		 *                              +
-		 *                      (16 levels)
-		 *                              +
-		 *                              V
-		 * 80           Kernel mode only
-		 * 79           System high priority
-		 *
-		 * spl/include/sys/sysmacros.h
-		 * #define maxclsyspri  89
-		 * #define minclsyspri  81  BASEPRI_KERNEL
-		 * #define defclsyspri  81  BASEPRI_KERNEL
-		 *
-		 * Calling policy.importance = 10 will create
-		 * a default pri (81) at pri (91).
-		 *
-		 * So asking for pri (85) we do 85-81 = 4.
-		 *
-		 * IllumOS priorities are:
-		 * #define MAXCLSYSPRI     99
-		 * #define MINCLSYSPRI     60
-		 */
+	if (name == NULL)
+		name = "unnamed zfs thread";
 
-		policy.importance = (pri - minclsyspri);
-
-		thread_policy_set(thread,
-		    THREAD_PRECEDENCE_POLICY,
-		    (thread_policy_t)&policy,
-		    THREAD_PRECEDENCE_POLICY_COUNT);
-	}
+	thread_set_thread_name(thread, name);
 
 	thread_deallocate(thread);
 
@@ -145,4 +112,176 @@ timeout_generic(int type, void (*func)(void *), void *arg,
 	 * untimeout_generic() they would pass it back to us
 	 */
 	return ((callout_id_t)arg);
+}
+
+#if (MACOS < 11) && MACOS_IMPURE
+extern void throttle_set_thread_io_policy(int priority);
+#endif
+
+void
+spl_throttle_set_thread_io_policy(int priority)
+{
+#if (MACOS < 11) && MACOS_IMPURE
+	throttle_set_thread_io_policy(priority);
+#endif
+}
+
+
+/*
+ * Set xnu kernel thread importance based on openzfs pri_t.
+ *
+ * Thread importance adjusts upwards and downards from
+ * BASEPRI_KERNEL (defined as 81).
+ *
+ * Many important kernel tasks run at BASEPRI_KERNEL,
+ * with networking and kernel graphics (Metal etc) running
+ * at BASEPRI_KERNEL + 1.
+ *
+ * We want maxclsyspri threads to have less xnu priority
+ * BASEPRI_KERNEL, so as to avoid UI stuttering, network
+ * disconnection and other side-effects of high zfs load with
+ * high thread priority.
+ *
+ * In <sysmacros.h> we define maxclsyspri to 80 with
+ * defclsyspri and minclsyspri set below that.
+ */
+
+void
+set_thread_importance_named(thread_t thread, pri_t pri, char *name)
+{
+	thread_precedence_policy_data_t policy = { 0 };
+
+	/*
+	 * start by finding an offset from BASEPRI_KERNEL,
+	 * which is found in osfmk/kern/sched.h
+	 */
+
+	policy.importance = pri - 81;
+
+	/* dont let ANY of our threads run as high as networking & GPU */
+	if (policy.importance > 0)
+		policy.importance = 0;
+	else if (policy.importance < (-11))
+		policy.importance = -11;
+
+	int i = policy.importance;
+	kern_return_t pol_prec_kret = thread_policy_set(thread,
+	    THREAD_PRECEDENCE_POLICY,
+	    (thread_policy_t)&policy,
+	    THREAD_PRECEDENCE_POLICY_COUNT);
+	if (pol_prec_kret != KERN_SUCCESS) {
+		printf("SPL: %s:%d: ERROR failed to set"
+		    " thread precedence to %d ret %d name %s\n",
+		    __func__, __LINE__, i, pol_prec_kret, name);
+	}
+}
+
+void
+set_thread_importance(thread_t thread, pri_t pri)
+{
+	set_thread_importance_named(thread, pri, "anonymous zfs thread");
+}
+
+/*
+ * Set a kernel throughput qos for this thread,
+ */
+
+void
+set_thread_throughput_named(thread_t thread,
+    thread_throughput_qos_t throughput, char *name)
+{
+	/*
+	 * TIERs: 0 is USER_INTERACTIVE, 1 is USER_INITIATED, 1 is LEGACY,
+	 *        2 is UTILITY, 5 is BACKGROUND, 5 is MAINTENANCE
+	 *
+	 *  (from xnu/osfmk/kern/thread_policy.c)
+	 */
+
+	thread_throughput_qos_policy_data_t qosp = { 0 };
+	qosp.thread_throughput_qos_tier = throughput;
+
+	kern_return_t qoskret = thread_policy_set(thread,
+	    THREAD_THROUGHPUT_QOS_POLICY,
+	    (thread_policy_t)&qosp,
+	    THREAD_THROUGHPUT_QOS_POLICY_COUNT);
+	if (qoskret != KERN_SUCCESS) {
+		printf("SPL: %s:%d: WARNING failed to set"
+		    " thread throughput policy retval: %d "
+		    " (THREAD_THROUGHPUT_QOS_POLICY %x), %s\n",
+		    __func__, __LINE__, qoskret,
+		    qosp.thread_throughput_qos_tier, name);
+	}
+}
+
+void
+set_thread_throughput(thread_t thread,
+    thread_throughput_qos_t throughput)
+{
+	set_thread_throughput_named(thread, throughput,
+	    "anonymous zfs function");
+}
+
+void
+set_thread_latency_named(thread_t thread,
+    thread_latency_qos_t latency, char *name)
+{
+	/*
+	 * TIERs: 0 is USER_INTERACTIVE, 1 is USER_INITIATED, 1 is LEGACY,
+	 *        3 is UTILITY, 3 is BACKGROUND, 5 is MAINTENANCE
+	 *
+	 *  (from xnu/osfmk/kern/thread_policy.c)
+	 * NB: these differ from throughput tier mapping
+	 */
+
+	thread_latency_qos_policy_data_t qosp = { 0 };
+	qosp.thread_latency_qos_tier = latency;
+	kern_return_t qoskret = thread_policy_set(thread,
+	    THREAD_LATENCY_QOS_POLICY,
+	    (thread_policy_t)&qosp,
+	    THREAD_LATENCY_QOS_POLICY_COUNT);
+	if (qoskret != KERN_SUCCESS) {
+		printf("SPL: %s:%d: WARNING failed to set"
+		    " thread latency policy retval: %d "
+		    " (THREAD_LATENCY_QOS_POLICY %x), %s",
+		    __func__, __LINE__,
+		    qoskret, qosp.thread_latency_qos_tier,
+		    name);
+	}
+}
+
+void
+set_thread_latency(thread_t thread,
+    thread_latency_qos_t latency)
+{
+	set_thread_latency_named(thread, latency, "anonymous zfs function");
+}
+
+/*
+ * XNU will dynamically adjust TIMESHARE
+ * threads around the chosen thread priority.
+ * The lower the importance (signed value),
+ * the more XNU will adjust a thread.
+ * Threads may be adjusted *upwards* from their
+ * base priority by XNU as well.
+ */
+
+void
+set_thread_timeshare_named(thread_t thread, char *name)
+{
+	thread_extended_policy_data_t policy = { .timeshare = TRUE };
+	kern_return_t kret = thread_policy_set(thread,
+	    THREAD_EXTENDED_POLICY,
+	    (thread_policy_t)&policy,
+	    THREAD_EXTENDED_POLICY_COUNT);
+	if (kret != KERN_SUCCESS) {
+		printf("SPL: %s:%d: WARNING failed to set"
+		    " timeshare policy retval: %d, %s\n",
+		    __func__, __LINE__, kret, name);
+	}
+}
+
+void
+set_thread_timeshare(thread_t thread)
+{
+	set_thread_timeshare_named(thread, "anonymous zfs function");
 }

--- a/module/os/macos/zfs/zvol_os.c
+++ b/module/os/macos/zfs/zvol_os.c
@@ -1094,8 +1094,9 @@ zvol_init(void)
 {
 	int threads = MIN(MAX(zvol_threads, 1), 1024);
 
-	zvol_taskq = taskq_create(ZVOL_DRIVER, threads, maxclsyspri,
-	    threads * 2, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
+	zvol_taskq = taskq_create(ZVOL_DRIVER, threads, maxclsyspri-4,
+	    threads * 2, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC
+	    | TASKQ_REALLY_DYNAMIC);
 	if (zvol_taskq == NULL) {
 		return (-ENOMEM);
 	}

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7663,9 +7663,19 @@ arc_init(void)
 	    offsetof(arc_prune_t, p_node));
 	mutex_init(&arc_prune_mtx, NULL, MUTEX_DEFAULT, NULL);
 
+#ifdef __APPLE__
+#ifndef _KERNEL
+#define	TASKQ_REALLY_DYNAMIC 0x0
+#endif
+	arc_prune_taskq = taskq_create("arc_prune", 100, defclsyspri,
+	    boot_ncpus, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC |
+	    TASKQ_REALLY_DYNAMIC |
+	    TASKQ_THREADS_CPU_PCT);
+#else
 	arc_prune_taskq = taskq_create("arc_prune", 100, defclsyspri,
 	    boot_ncpus, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC |
 	    TASKQ_THREADS_CPU_PCT);
+#endif
 
 	arc_ksp = kstat_create("zfs", 0, "arcstats", "misc", KSTAT_TYPE_NAMED,
 	    sizeof (arc_stats) / sizeof (kstat_named_t), KSTAT_FLAG_VIRTUAL);

--- a/module/zfs/metaslab.c
+++ b/module/zfs/metaslab.c
@@ -850,9 +850,17 @@ metaslab_group_create(metaslab_class_t *mc, vdev_t *vd, int allocators)
 		metaslab_group_allocator_t *mga = &mg->mg_allocator[i];
 		zfs_refcount_create_tracked(&mga->mga_alloc_queue_depth);
 	}
-
+#ifdef __APPLE__
+#ifndef _KERNEL
+#define	TASKQ_REALLY_DYNAMIC 0x0
+#endif
+	mg->mg_taskq = taskq_create("metaslab_group_taskq", metaslab_load_pct,
+	    maxclsyspri, 10, INT_MAX, TASKQ_THREADS_CPU_PCT | TASKQ_DYNAMIC
+	    | TASKQ_REALLY_DYNAMIC);
+#else
 	mg->mg_taskq = taskq_create("metaslab_group_taskq", metaslab_load_pct,
 	    maxclsyspri, 10, INT_MAX, TASKQ_THREADS_CPU_PCT | TASKQ_DYNAMIC);
+#endif
 
 	return (mg);
 }


### PR DESCRIPTION
Make our threads less like angry bees, and give them names.

WIP: what to do about two exports :

```
kxld[net.lundman.zfs]: The following symbols are unresolved for this kext:
kxld[net.lundman.zfs]:     _thread_set_cpulimit
kxld[net.lundman.zfs]:     _throttle_set_thread_io_policy
```

These could be nerfed with just a performance impact, to keep things pure.
