### PR TITLE
Improve LDI-attached disk performance

### DIFF
--- a/module/os/macos/zfs/ldi_vnode.c
+++ b/module/os/macos/zfs/ldi_vnode.c
@@ -566,7 +566,9 @@ buf_strategy_vnode(ldi_buf_t *lbp, struct ldi_handle *lhp)
 
 	/* Setup buffer */
 	buf_setflags(bp, B_NOCACHE | (lbp->b_flags & B_READ ?
-	    B_READ : B_WRITE));
+	    B_READ : B_WRITE) |
+	    (lbp->b_flags & (B_PASSIVE | B_PHYS | B_RAW)) |
+	    ((lbp->b_iodone == NULL) ? 0: B_ASYNC));
 	buf_setcount(bp, lbp->b_bcount);
 	buf_setdataptr(bp, (uintptr_t)lbp->b_un.b_addr);
 	buf_setblkno(bp, lbp->b_lblkno);


### PR DESCRIPTION
* quiet some build noise with pragmas

* use IOKit barrier synchronization where possible

* make async I/O really asynchronous

* adjust I/O priorities

* passivate I/O where can at this layer, to sidestep the system I/O throttle, while engaging constructively with the throttle where we cannot