### PR TITLE
abd_cache fragmentation mitigation

### DIFF
--- a/include/os/macos/spl/sys/vmem.h
+++ b/include/os/macos/spl/sys/vmem.h
@@ -169,6 +169,7 @@ extern size_t vmem_size_semi_atomic(vmem_t *, int);
 extern void vmem_qcache_reap(vmem_t *vmp);
 extern int64_t vmem_buckets_size(int);
 extern int64_t abd_arena_empty_space(void);
+extern int64_t abd_arena_total_size(void);
 
 #ifdef	__cplusplus
 }

--- a/module/os/macos/spl/spl-vmem.c
+++ b/module/os/macos/spl/spl-vmem.c
@@ -3844,6 +3844,16 @@ abd_arena_empty_space(void)
 	return (headroom);
 }
 
+int64_t
+abd_arena_total_size(void)
+{
+	extern vmem_t *abd_arena;
+
+	if (abd_arena != NULL)
+		return (abd_arena->vm_kstat.vk_mem_total.value.ui64);
+}
+
+
 /*
  * return true if the bucket for size is fragmented
  */

--- a/module/os/macos/zfs/zfs_vnops_osx.c
+++ b/module/os/macos/zfs/zfs_vnops_osx.c
@@ -979,7 +979,7 @@ transfer_out:
 		case HFS_GET_BOOT_INFO:
 			{
 				u_int32_t vcbFndrInfo[8];
-				printf("%s HFS_GET_BOOT_INFO\n", __func__);
+				dprintf("%s HFS_GET_BOOT_INFO\n", __func__);
 				/*
 				 * ZFS booting is not supported, mimic selection
 				 * of a non-root HFS volume


### PR DESCRIPTION
Try to keep the spread between kstat.vmem.vmem.abd_cache.mem_import (amount obtained ultimately from xnu) and kstat.vmem.vmem.abd_cache.mem_inuse (amount given to the abd_chunk kmem_cache for holding ABDs) much much smaller than it can be.

This in turn keeps overall memory use lower, and helps ARC find a more stable equilibrium size.

Additionally, change a sometimes very noisy but low-value printf to a dprintf.



