### PR TITLE
Tidying nvram zfs_boot=pool

### DIFF
--- a/include/os/macos/spl/stddef.h
+++ b/include/os/macos/spl/stddef.h
@@ -28,6 +28,7 @@
 #ifndef _SPL_STDDEF_H
 #define	_SPL_STDDEF_H
 
+#include <TargetConditionals.h>
 #include <AvailabilityMacros.h>
 #if defined(MAC_OS_X_VERSION_10_12) &&	\
 	(MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)


### PR DESCRIPTION
If zfs_boot is set we run a long-lived
zfs_boot_import_thread, which can stay running until the
kernel module is running _fini() functions at unload or
shutdown.

This patch dispatches it on a zfs_boot() taskq, to avoid
causing a hang at the taskq_wait_outstanding(system_taskq,
0) in zvol.c's zvol_create_minors_recursive(), which would
prevent pool imports finishing if the pool contained
zvols.  (Symptoms: "zpool import" does not exit for any
pool, system does not see any zvols).

This exposed a long-term race condition in our
zfs_boot.cpp: the notifier can cause the
mutex_enter(&pools->lock) in zfs_boot_probe_media to be
reached before the mutex_enter() after the notifier was
created.   The use of the system_taskq was masking that,
by quietly imposing a serialization choke.

Moving the mutex and cv initialization earlier -- in
particular before the notifier is created -- eliminates
the race.

Further tidying in zfs_boot.cpp, including some
cstyling, switching to _Atomic instead of volatile.
Volatile is for effectively random reads; _Atomic is for
when we want many readers to have a consistent view after
the variable is written.

Finally, we need TargetConditionals.h in front of
AvailabilityMacros.h in order to build.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
