### PR TITLE
Add includes to build on Big Sur with macports-clang-11 

### DIFF
--- a/cmd/os/macos/InvariantDisks/InvariantDisks/IDLogUtils.cpp
+++ b/cmd/os/macos/InvariantDisks/InvariantDisks/IDLogUtils.cpp
@@ -17,6 +17,7 @@
 // Auto Detect the use of ASL or OS Log if it is not already enforced by the
 // build environment
 #if !(defined(ID_USE_ASL) || defined(ID_USE_OS_LOG))
+	#include <TargetConditionals.h>
 	#include <AvailabilityMacros.h>
 	#if defined (MAC_OS_X_VERSION_10_12) && (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)
 		#define ID_USE_OS_LOG

--- a/include/os/macos/spl/libkern/libkern.h
+++ b/include/os/macos/spl/libkern/libkern.h
@@ -32,6 +32,10 @@
  * We wrap this header to handle that copyinstr()'s final argument is
  * mandatory on OSX. Wrap it to call our ddi_copyinstr to make it optional.
  */
+
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
+
 #include_next <libkern/libkern.h>
 #undef copyinstr
 #define	copyinstr(U, K, L, D) ddi_copyinstr((U), (K), (L), (D))

--- a/include/os/macos/spl/sys/byteorder.h
+++ b/include/os/macos/spl/sys/byteorder.h
@@ -28,6 +28,9 @@
 #ifndef _SPL_BYTEORDER_H
 #define	_SPL_BYTEORDER_H
 
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
+
 #include <libkern/OSByteOrder.h>
 #include <machine/byte_order.h>
 

--- a/include/os/macos/spl/sys/cred.h
+++ b/include/os/macos/spl/sys/cred.h
@@ -39,6 +39,7 @@ typedef struct ucred cred_t;
 #define	KUID_TO_SUID(x)		(x)
 #define	KGID_TO_SGID(x)		(x)
 
+#include <TargetConditionals.h>
 #include <AvailabilityMacros.h>
 
 // Older OSX API

--- a/include/os/macos/spl/sys/fcntl.h
+++ b/include/os/macos/spl/sys/fcntl.h
@@ -28,6 +28,7 @@
 #ifndef _SPL_FCNTL_H
 #define	_SPL_FCNTL_H
 
+#include <TargetConditionals.h>
 #include <AvailabilityMacros.h>
 #if !defined(MAC_OS_X_VERSION_10_9) ||	\
 	(MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_9)

--- a/include/os/macos/spl/sys/mutex.h
+++ b/include/os/macos/spl/sys/mutex.h
@@ -30,6 +30,9 @@
 #ifndef OSX_MUTEX_H
 #define	OSX_MUTEX_H
 
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
+
 #include <libkern/locks.h>
 
 #include <libkern/OSAtomic.h>

--- a/include/os/macos/spl/sys/param.h
+++ b/include/os/macos/spl/sys/param.h
@@ -28,6 +28,9 @@
 #ifndef _SPL_PARAM_H
 #define	_SPL_PARAM_H
 
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
+
 #include_next <sys/param.h>
 #include <mach/vm_param.h>
 

--- a/include/os/macos/spl/sys/types.h
+++ b/include/os/macos/spl/sys/types.h
@@ -37,6 +37,7 @@
 #include <sys/sysmacros.h>
 #include <stddef.h>
 
+#include <TargetConditionals.h>
 #include <AvailabilityMacros.h>
 #if !defined(MAC_OS_X_VERSION_10_12) ||	\
 	(MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_12)

--- a/include/os/macos/spl/sys/types.h
+++ b/include/os/macos/spl/sys/types.h
@@ -32,13 +32,13 @@
 #define	likely(x)		__builtin_expect(!!(x), 1)
 #define	unlikely(x)		__builtin_expect(!!(x), 0)
 
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
 #include_next <sys/types.h>
 #include <string.h>
 #include <sys/sysmacros.h>
 #include <stddef.h>
 
-#include <TargetConditionals.h>
-#include <AvailabilityMacros.h>
 #if !defined(MAC_OS_X_VERSION_10_12) ||	\
 	(MAC_OS_X_VERSION_MIN_REQUIRED <= MAC_OS_X_VERSION_10_12)
 #include <i386/types.h>

--- a/include/os/macos/zfs/sys/ZFSDataset.h
+++ b/include/os/macos/zfs/sys/ZFSDataset.h
@@ -28,6 +28,7 @@
 #ifdef __cplusplus
 
 #include <IOKit/storage/IOMedia.h>
+#include <TargetConditionals.h>
 #include <AvailabilityMacros.h>
 
 #ifdef super

--- a/lib/libspl/include/os/macos/sys/time.h
+++ b/lib/libspl/include/os/macos/sys/time.h
@@ -23,6 +23,7 @@
 #define	_LIBSPL_SYS_OSX_TIME_H
 
 #include_next <sys/time.h>
+#include <TargetConditionals.h>
 #include <AvailabilityMacros.h>
 
 /*

--- a/lib/libspl/include/os/macos/time.h
+++ b/lib/libspl/include/os/macos/time.h
@@ -23,6 +23,7 @@
 #define	_LIBSPL_TIME_H
 
 #include_next <time.h>
+#include <TargetConditionals.h>
 #include <AvailabilityMacros.h>
 
 /* Linux also has a timer_create() API we need to emulate. */

--- a/module/os/macos/spl/spl-vnode.c
+++ b/module/os/macos/spl/spl-vnode.c
@@ -36,6 +36,7 @@
 #include <IOKit/IOLib.h>
 
 #include <sys/taskq.h>
+#include <TargetConditionals.h>
 #include <AvailabilityMacros.h>
 
 int

--- a/module/os/macos/zfs/arc_os.c
+++ b/module/os/macos/zfs/arc_os.c
@@ -26,6 +26,8 @@
  * Copyright 2017 Nexenta Systems, Inc.  All rights reserved.
  */
 
+#include <TargetConditionals.h>
+#include <AvailabilityMacros.h>
 #include <IOKit/IOLib.h>
 #include <sys/spa.h>
 #include <sys/zio.h>


### PR DESCRIPTION
Building on Big Sur with macports-clang-11 errors when the appropriate TARGET macros are not already defined.   Include TargetConditionals.h before each AvailabilityMacros.h already in the code, and add both where needed to complete the build.
