### PR TITLE
Fix abd leak, kmem_free correct size of abd_t for macOS and Freebsd, and improve macOS abd performance

### DIFF
--- a/include/sys/abd_impl.h
+++ b/include/sys/abd_impl.h
@@ -63,7 +63,7 @@ void abd_free_struct(abd_t *);
  */
 
 abd_t *abd_alloc_struct_impl(size_t);
-abd_t *abd_get_offset_scatter(abd_t *, abd_t *, size_t);
+abd_t *abd_get_offset_scatter(abd_t *, abd_t *, size_t, size_t);
 void abd_free_struct_impl(abd_t *);
 void abd_alloc_chunks(abd_t *, size_t);
 void abd_free_chunks(abd_t *);

--- a/module/os/freebsd/zfs/abd_os.c
+++ b/module/os/freebsd/zfs/abd_os.c
@@ -329,14 +329,17 @@ abd_alloc_for_io(size_t size, boolean_t is_metadata)
 }
 
 abd_t *
-abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off)
+abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off,
+    size_t size)
 {
 	abd_verify(sabd);
 	ASSERT3U(off, <=, sabd->abd_size);
 
 	size_t new_offset = ABD_SCATTER(sabd).abd_offset + off;
-	uint_t chunkcnt = abd_scatter_chunkcnt(sabd) -
-	    (new_offset / zfs_abd_chunk_size);
+	size_t chunkcnt = abd_chunkcnt_for_bytes(
+	    (new_offset % zfs_abd_chunk_size) + size);
+
+	ASSERT3U(chunkcnt, <=, abd_scatter_chunkcnt(sabd));
 
 	/*
 	 * If an abd struct is provided, it is only the minimum size.  If we

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -760,7 +760,7 @@ abd_alloc_for_io(size_t size, boolean_t is_metadata)
 }
 
 abd_t *
-abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off)
+abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off, size_t size)
 {
 	int i = 0;
 	struct scatterlist *sg = NULL;

--- a/module/os/linux/zfs/abd_os.c
+++ b/module/os/linux/zfs/abd_os.c
@@ -760,7 +760,8 @@ abd_alloc_for_io(size_t size, boolean_t is_metadata)
 }
 
 abd_t *
-abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off, size_t size)
+abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off,
+    __unused size_t size)
 {
 	int i = 0;
 	struct scatterlist *sg = NULL;

--- a/module/os/macos/spl/spl-kmem.c
+++ b/module/os/macos/spl/spl-kmem.c
@@ -339,6 +339,7 @@ size_t	kmem_max_cached = KMEM_BIG_MAXBUF;	/* maximum kmem_alloc cache */
 // can be 0 or KMF_LITE
 // or KMF_DEADBEEF | KMF_REDZONE | KMF_CONTENTS
 // with or without KMF_AUDIT
+// int kmem_flags = KMF_DEADBEEF | KMF_REDZONE | KMF_CONTENTS | KMF_AUDIT;
 int kmem_flags = KMF_LITE;
 #else
 int kmem_flags = 0;
@@ -4364,7 +4365,6 @@ spl_free_reap_caches(void)
 	if (curtime - last_reap < reap_after)
 		return;
 
-	vmem_qcache_reap(abd_arena);
 	kmem_reap();
 	vmem_qcache_reap(kmem_va_arena);
 }

--- a/module/os/macos/spl/spl-seg_kmem.c
+++ b/module/os/macos/spl/spl-seg_kmem.c
@@ -268,7 +268,7 @@ segkmem_abd_init()
 
 	abd_arena = vmem_create("abd_cache", NULL, 0,
 	    PAGESIZE, vmem_alloc, vmem_free, spl_heap_arena,
-	    131072, VM_SLEEP | VMC_NO_QCACHE | VM_BESTFIT);
+	    131072, VM_SLEEP | VMC_NO_QCACHE | VM_FIRSTFIT);
 
 	ASSERT(abd_arena != NULL);
 }

--- a/module/zfs/abd.c
+++ b/module/zfs/abd.c
@@ -531,7 +531,7 @@ abd_get_offset_impl(abd_t *abd, abd_t *sabd, size_t off, size_t size)
 		}
 		ASSERT3U(left, ==, 0);
 	} else {
-		abd = abd_get_offset_scatter(abd, sabd, off);
+		abd = abd_get_offset_scatter(abd, sabd, off, size);
 	}
 
 	ASSERT3P(abd, !=, NULL);


### PR DESCRIPTION
macOS_pure is leaking kstat.zfs.misc.abdstats.struct_size most noticeably when there is a raidz2 with four disks (or any raidzN with more data columns than N), because the ABD_FLAG_ALLOCD flag was being cleared shortly after allocation by abd_alloc_struct_impl() under abd_get_offset_scatter().  Consequently, abd_free would not free the abd_t.

Once the flag was no longer cleared, heap corruption was detected because abd_get_offset_scatter() was calculating a large chunkcnt.   This results in (a) needlessly abandoning viable supplied ABDs, (b) needless copying and carrying of chunk pointers, and (c) a mismatch between the number of chunks allocated for and abd->abd_size set in abd_get_offset_impl().   Since abd_free_struct_impl() calculates the number of chunks to free (and thus the size to be given to kmem_free) based on abd->abd_size, this resulted in kmem_free being given the wrong size.   This can lead to heap corruption, and generally panics with any kmem debugging enabled.

Things done in the process of producing the squashed final PR : 

Pass the desired size to abd_get_offset_scatter() [changing its signature] so that it can calculate the same result as abd_free_struct_impl().

WIP verification: save the initial abd_alloc_struct_impl() kmem_alloc()  size in abd->abd_orig_size, and VERIFY that against the size calculated in abd_free_struct_impl()

additional kmem debugging

Some performance improvements (at least for Intel) in the abd_cache arena and the abd_chunks kmem cache.

Todo: let tester run, port chunkcnt change to freebsd as it has an identical issue; check to see if linux is also carrying too many chunks around in its sg list; strip out abd_orig_size; revert to KMF_LITE debugging for DEBUG builds.