### PR TITLE
Upstream: unmount snapshots before destroying them

### DIFF
--- a/include/libzfs.h
+++ b/include/libzfs.h
@@ -641,6 +641,7 @@ extern int zfs_create_ancestors(libzfs_handle_t *, const char *);
 extern int zfs_destroy(zfs_handle_t *, boolean_t);
 extern int zfs_destroy_snaps(zfs_handle_t *, char *, boolean_t);
 extern int zfs_destroy_snaps_nvl(libzfs_handle_t *, nvlist_t *, boolean_t);
+extern int zfs_destroy_snaps_nvl_os(libzfs_handle_t *, nvlist_t *);
 extern int zfs_clone(zfs_handle_t *, const char *, nvlist_t *);
 extern int zfs_snapshot(libzfs_handle_t *, const char *, boolean_t, nvlist_t *);
 extern int zfs_snapshot_nvl(libzfs_handle_t *hdl, nvlist_t *snaps,

--- a/lib/libzfs/Makefile.am
+++ b/lib/libzfs/Makefile.am
@@ -47,6 +47,7 @@ endif
 
 if BUILD_MACOS
 USER_C += \
+	os/macos/libzfs_dataset_os.c \
 	os/macos/libzfs_getmntany.c \
 	os/macos/libzfs_mount_os.c \
 	os/macos/libzfs_pool_os.c \

--- a/lib/libzfs/libzfs_dataset.c
+++ b/lib/libzfs/libzfs_dataset.c
@@ -3937,9 +3937,15 @@ zfs_destroy_snaps(zfs_handle_t *zhp, char *snapname, boolean_t defer)
 int
 zfs_destroy_snaps_nvl(libzfs_handle_t *hdl, nvlist_t *snaps, boolean_t defer)
 {
-	int ret;
+	int ret = 0;
 	nvlist_t *errlist = NULL;
 	nvpair_t *pair;
+
+#ifdef __APPLE__
+	ret = zfs_destroy_snaps_nvl_os(hdl, snaps);
+	if (ret != 0)
+		return (ret);
+#endif
 
 	ret = lzc_destroy_snaps(snaps, defer, &errlist);
 

--- a/lib/libzfs/os/macos/libzfs_dataset_os.c
+++ b/lib/libzfs/os/macos/libzfs_dataset_os.c
@@ -1,0 +1,27 @@
+#include <libintl.h>
+#include "libzfs_impl.h"
+
+int
+zfs_destroy_snaps_nvl_os(libzfs_handle_t *hdl, nvlist_t *snaps)
+{
+	struct mnttab entry;
+	int ret = 0;
+	nvpair_t *pair;
+
+	for (pair = nvlist_next_nvpair(snaps, NULL);
+	    pair != NULL;
+	    pair = nvlist_next_nvpair(snaps, pair)) {
+		zfs_handle_t *zhp = zfs_open(hdl, nvpair_name(pair),
+		    ZFS_TYPE_SNAPSHOT);
+		if (zhp != NULL) {
+			if (zfs_get_type(zhp) == ZFS_TYPE_SNAPSHOT &&
+			    libzfs_mnttab_find(hdl, zhp->zfs_name, &entry)
+			    == 0)
+				ret |= zfs_snapshot_unmount(zhp, MS_FORCE);
+			zfs_close(zhp);
+		}
+	}
+	if (ret != 0)
+		fprintf(stderr, gettext("could not unmount snapshot(s)\n"));
+	return (ret);
+}


### PR DESCRIPTION
Fixes https://github.com/openzfsonosx/openzfs/issues/66.