### PR TITLE
Upstream: fix linkage on macOS 12

### DIFF
--- a/cmd/zdb/Makefile.am
+++ b/cmd/zdb/Makefile.am
@@ -13,6 +13,7 @@ zdb_SOURCES = \
 zdb_LDADD = \
 	$(abs_top_builddir)/lib/libzpool/libzpool.la \
 	$(abs_top_builddir)/lib/libzfs_core/libzfs_core.la \
-	$(abs_top_builddir)/lib/libnvpair/libnvpair.la
+	$(abs_top_builddir)/lib/libnvpair/libnvpair.la \
+	$(abs_top_builddir)/lib/libzfs/libzfs.la
 
 include $(top_srcdir)/config/CppCheck.am

--- a/cmd/zhack/Makefile.am
+++ b/cmd/zhack/Makefile.am
@@ -11,6 +11,7 @@ zhack_SOURCES = \
 zhack_LDADD = \
 	$(abs_top_builddir)/lib/libzpool/libzpool.la \
 	$(abs_top_builddir)/lib/libzfs_core/libzfs_core.la \
-	$(abs_top_builddir)/lib/libnvpair/libnvpair.la
+	$(abs_top_builddir)/lib/libnvpair/libnvpair.la \
+	$(abs_top_builddir)/lib/libzfs/libzfs.la
 
 include $(top_srcdir)/config/CppCheck.am

--- a/cmd/ztest/Makefile.am
+++ b/cmd/ztest/Makefile.am
@@ -17,7 +17,8 @@ ztest_SOURCES = \
 ztest_LDADD = \
 	$(abs_top_builddir)/lib/libzpool/libzpool.la \
 	$(abs_top_builddir)/lib/libzfs_core/libzfs_core.la \
-	$(abs_top_builddir)/lib/libnvpair/libnvpair.la
+	$(abs_top_builddir)/lib/libnvpair/libnvpair.la \
+	$(abs_top_builddir)/lib/libzfs/libzfs.la
 
 ztest_LDADD += -lm
 ztest_LDFLAGS = -pthread

--- a/include/sys/zio_crypt.h
+++ b/include/sys/zio_crypt.h
@@ -148,7 +148,7 @@ int zio_crypt_do_hmac(zio_crypt_key_t *key, uint8_t *data, uint_t datalen,
     uint8_t *digestbuf, uint_t digestlen);
 int zio_crypt_do_objset_hmacs(zio_crypt_key_t *key, void *data, uint_t datalen,
     boolean_t byteswap, uint8_t *portable_mac, uint8_t *local_mac);
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(_KERNEL)
 int zio_crypt_do_objset_hmacs_errata1(zio_crypt_key_t *key, void *data,
     uint_t datalen, boolean_t should_bswap, uint8_t *portable_mac,
     uint8_t *local_mac);

--- a/lib/libicp/Makefile.am
+++ b/lib/libicp/Makefile.am
@@ -17,6 +17,9 @@ ASM_SOURCES_AS = \
 	asm-x86_64/os/macos/aes/aes_amd64.S \
 	asm-x86_64/os/macos/aes/aes_aesni.S \
 	asm-x86_64/os/macos/modes/gcm_pclmulqdq.S \
+	asm-x86_64/os/macos/modes/aesni-gcm-x86_64.S \
+	asm-x86_64/os/macos/modes/ghash-x86_64.S \
+	asm-x86_64/os/macos/sha1/sha1-x86_64.S \
 	asm-x86_64/os/macos/sha2/sha256_impl.S \
 	asm-x86_64/os/macos/sha2/sha512_impl.S
 else

--- a/module/os/macos/zfs/zfs_vnops_osx_lib.c
+++ b/module/os/macos/zfs/zfs_vnops_osx_lib.c
@@ -2219,17 +2219,3 @@ uio_prefaultpages(ssize_t n, struct uio *uio)
 {
 	return (0);
 }
-
-/* No #pragma weaks here! */
-void
-dmu_buf_add_ref(dmu_buf_t *db, void *tag)
-{
-	dbuf_add_ref((dmu_buf_impl_t *)db, tag);
-}
-
-boolean_t
-dmu_buf_try_add_ref(dmu_buf_t *db, objset_t *os, uint64_t object,
-    uint64_t blkid, void *tag)
-{
-	return (dbuf_try_add_ref(db, os, object, blkid, tag));
-}

--- a/module/zfs/dbuf.c
+++ b/module/zfs/dbuf.c
@@ -3544,7 +3544,7 @@ dbuf_rm_spill(dnode_t *dn, dmu_tx_t *tx)
 	dbuf_free_range(dn, DMU_SPILL_BLKID, DMU_SPILL_BLKID, tx);
 }
 
-#pragma weak dmu_buf_add_ref = dbuf_add_ref
+
 void
 dbuf_add_ref(dmu_buf_impl_t *db, void *tag)
 {
@@ -3552,7 +3552,6 @@ dbuf_add_ref(dmu_buf_impl_t *db, void *tag)
 	VERIFY3S(holds, >, 1);
 }
 
-#pragma weak dmu_buf_try_add_ref = dbuf_try_add_ref
 boolean_t
 dbuf_try_add_ref(dmu_buf_t *db_fake, objset_t *os, uint64_t obj, uint64_t blkid,
     void *tag)
@@ -3574,6 +3573,19 @@ dbuf_try_add_ref(dmu_buf_t *db_fake, objset_t *os, uint64_t obj, uint64_t blkid,
 		mutex_exit(&found_db->db_mtx);
 	}
 	return (result);
+}
+
+void
+dmu_buf_add_ref(dmu_buf_t *db, void *tag)
+{
+	dbuf_add_ref((dmu_buf_impl_t *)db, tag);
+}
+
+boolean_t
+dmu_buf_try_add_ref(dmu_buf_t *db, objset_t *os, uint64_t object,
+    uint64_t blkid, void *tag)
+{
+	return (dbuf_try_add_ref(db, os, object, blkid, tag));
 }
 
 /*

--- a/module/zfs/dsl_crypt.c
+++ b/module/zfs/dsl_crypt.c
@@ -2701,7 +2701,7 @@ spa_do_crypt_objset_mac_abd(boolean_t generate, spa_t *spa, uint64_t dsobj,
 		return (0);
 	}
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(_KERNEL)
 	/*
 	 * Unfortunate errata case, see module/os/macos/zfs/zio_crypt.c
 	 * If portable is GOOD, but local_mac is BAD - recompute


### PR DESCRIPTION
These changes prevent "dyld[678]: symbol not found in flat namespace"
for several symbols.

Xcode 13 and/or Monterey has stricter checks for undefined symbols. Note
that binaries running on macOS 12, but built on macOS 11 with Xcode 12,
don't trigger these checks for some reason.