### PR TITLE
Change zvol type from "Image/file" to "internal/external"

### DIFF
--- a/module/os/macos/zfs/zvolIO.cpp
+++ b/module/os/macos/zfs/zvolIO.cpp
@@ -125,8 +125,8 @@ org_openzfsonosx_zfs_zvol_device::attach(IOService* provider)
 
 	/*
 	 * We want to set some additional properties for ZVOLs, in
-	 * particular, "Virtual Device", and type "File"
-	 * (or is Internal better?)
+	 * particular, "Virtual Device", and type "USB"
+	 * and setting it to "internal/external"
 	 *
 	 * Finally "Generic" type.
 	 *
@@ -153,7 +153,19 @@ org_openzfsonosx_zfs_zvol_device::attach(IOService* provider)
 	propSymbol->release();
 	propSymbol = 0;
 
-	propSymbol = OSSymbol::withCString(kIOPropertyExternalKey);
+	propSymbol = OSSymbol::withCString(
+		kIOPropertyPhysicalInterconnectTypeUSB);
+	if (!propSymbol) {
+		IOLog("could not create interconnect location string\n");
+		return (true);
+	}
+	protocolCharacteristics->setObject(
+	    kIOPropertyPhysicalInterconnectTypeKey, propSymbol);
+	
+	propSymbol->release();
+	propSymbol = 0;
+
+	propSymbol = OSSymbol::withCString(kIOPropertyInternalExternalKey);
 	if (!propSymbol) {
 		IOLog("could not create interconnect location string\n");
 		return (true);

--- a/module/os/macos/zfs/zvolIO.cpp
+++ b/module/os/macos/zfs/zvolIO.cpp
@@ -153,7 +153,7 @@ org_openzfsonosx_zfs_zvol_device::attach(IOService* provider)
 	propSymbol->release();
 	propSymbol = 0;
 
-	propSymbol = OSSymbol::withCString(kIOPropertyInterconnectFileKey);
+	propSymbol = OSSymbol::withCString(kIOPropertyExternalKey);
 	if (!propSymbol) {
 		IOLog("could not create interconnect location string\n");
 		return (true);


### PR DESCRIPTION
Previously, zvols were connected  "files" according to the apple specification in https://opensource.apple.com/source/IOStorageFamily/IOStorageFamily-260.100.1/IOStorageProtocolCharacteristics.h.auto.html.

Changing it from kIOPropertyInterconnectFileKey to kIOPropertyInternalExternalKey makes most sense as Apple itself writes about

kIOPropertyInternalExternalKey

```
This key defines the value of Internal/External for the key
kIOPropertyPhysicalInterconnectLocationKey. If the device is connected
to a bus and it is indeterminate whether it is internal or external,
this key should be set.
```

This would likely solve #85 

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
