### PR TITLE
WIP: use sub-PAGESIZE scatter chunks instead of linears for small ABDs

### DIFF
--- a/include/os/macos/spl/sys/seg_kmem.h
+++ b/include/os/macos/spl/sys/seg_kmem.h
@@ -41,8 +41,9 @@ extern "C" {
 
 extern uint64_t segkmem_total_allocated;
 
-/* qcaching for abd */
+/* segregated vmem arenas for abd */
 extern vmem_t *abd_arena;
+extern vmem_t *abd_subpage_arena;
 
 /*
  * segkmem page vnodes

--- a/module/os/macos/zfs/abd_os.c
+++ b/module/os/macos/zfs/abd_os.c
@@ -13,6 +13,7 @@
  * Copyright (c) 2014 by Chunwei Chen. All rights reserved.
  * Copyright (c) 2016 by Delphix. All rights reserved.
  * Copyright (c) 2020 by Jorgen Lundman. All rights reserved.
+ * Copyright (c) 2021 by Sean Doran. All rights reserved.
  */
 
 /*
@@ -77,11 +78,41 @@ static abd_stats_t abd_stats = {
  * will cause the machine to panic if you change it and try to access the data
  * within a scattered ABD.
  */
-size_t zfs_abd_chunk_size = 4096;
+
+#if defined(__arm64__)
+/*
+ * On ARM macOS, PAGE_SIZE is not a runtime constant!  So here we have to
+ * guess at compile time.  There a balance between fewer kmem_caches, more
+ * memory use by "tails" of medium-sized ABDs, and more memory use by
+ * accounting structures if we use 4k versus 16k.
+ *
+ * Since the original *subpage* design expected PAGE_SIZE to be constant and
+ * the pre-subpage ABDs used PAGE_SIZE without requiring it to be a
+ * compile-time constant, let's use 16k initially and adjust downwards based
+ * on feedback.
+ */
+#define	ABD_PGSIZE	16384
+#else
+#define	ABD_PGSIZE	PAGE_SIZE
+#endif
+
+const static size_t zfs_abd_chunk_size = ABD_PGSIZE;
 
 kmem_cache_t *abd_chunk_cache;
 static kstat_t *abd_ksp;
 
+/*
+ * Sub-ABD_PGSIZE allocations are segregated into kmem caches.  This may be
+ * inefficient or counterproductive if in future the following conditions are
+ * not met.
+ */
+_Static_assert(SPA_MINBLOCKSHIFT == 9, "unexpected SPA_MINSBLOCKSHIFT != 9");
+_Static_assert(ISP2(ABD_PGSIZE), "ABD_PGSIZE unexpectedly non power of 2");
+_Static_assert(ABD_PGSIZE >= 4096, "ABD_PGSIZE unexpectedly smaller than 4096");
+_Static_assert(ABD_PGSIZE <= 16384,
+	"ABD_PGSIZE unexpectedly larger than 16384");
+
+kmem_cache_t *abd_subpage_cache[ABD_PGSIZE >> SPA_MINBLOCKSHIFT] = { NULL };
 
 /*
  * We use a scattered SPA_MAXBLOCKSIZE sized ABD whose chunks are
@@ -98,16 +129,16 @@ abd_free_chunk(void *c)
 	kmem_cache_free(abd_chunk_cache, c);
 }
 
-static size_t
+static inline size_t
 abd_chunkcnt_for_bytes(size_t size)
 {
 	return (P2ROUNDUP(size, zfs_abd_chunk_size) / zfs_abd_chunk_size);
 }
 
-static inline size_t
+static size_t
 abd_scatter_chunkcnt(abd_t *abd)
 {
-	ASSERT(!abd_is_linear(abd));
+	VERIFY(!abd_is_linear(abd));
 	return (abd_chunkcnt_for_bytes(
 	    ABD_SCATTER(abd).abd_offset + abd->abd_size));
 }
@@ -115,7 +146,7 @@ abd_scatter_chunkcnt(abd_t *abd)
 boolean_t
 abd_size_alloc_linear(size_t size)
 {
-	return (size <= zfs_abd_chunk_size ? B_TRUE : B_FALSE);
+	return (B_FALSE);
 }
 
 void
@@ -127,12 +158,12 @@ abd_update_scatter_stats(abd_t *abd, abd_stats_op_t op)
 		ABDSTAT_BUMP(abdstat_scatter_cnt);
 		ABDSTAT_INCR(abdstat_scatter_data_size, abd->abd_size);
 		ABDSTAT_INCR(abdstat_scatter_chunk_waste,
-		    n * zfs_abd_chunk_size - abd->abd_size);
+		    n * ABD_SCATTER(abd).abd_chunk_size - abd->abd_size);
 	} else {
 		ABDSTAT_BUMPDOWN(abdstat_scatter_cnt);
 		ABDSTAT_INCR(abdstat_scatter_data_size, -(int)abd->abd_size);
 		ABDSTAT_INCR(abdstat_scatter_chunk_waste,
-		    abd->abd_size - n * zfs_abd_chunk_size);
+		    abd->abd_size - n * ABD_SCATTER(abd).abd_chunk_size);
 	}
 }
 
@@ -159,31 +190,83 @@ abd_verify_scatter(abd_t *abd)
 	VERIFY(!abd_is_linear_page(abd));
 	VERIFY3U(ABD_SCATTER(abd).abd_offset, <,
 	    zfs_abd_chunk_size);
+	VERIFY3U(ABD_SCATTER(abd).abd_offset, <,
+	    ABD_SCATTER(abd).abd_chunk_size);
+	VERIFY3U(ABD_SCATTER(abd).abd_chunk_size, >=,
+	    SPA_MINBLOCKSIZE);
 
 	size_t n = abd_scatter_chunkcnt(abd);
+
+	if (ABD_SCATTER(abd).abd_chunk_size != ABD_PGSIZE) {
+		VERIFY3U(n, ==, 1);
+		VERIFY3U(ABD_SCATTER(abd).abd_chunk_size, <, ABD_PGSIZE);
+		VERIFY3U(abd->abd_size, <=, ABD_SCATTER(abd).abd_chunk_size);
+	}
+
 	for (int i = 0; i < n; i++) {
-		ASSERT3P(
+		VERIFY3P(
 		    ABD_SCATTER(abd).abd_chunks[i], !=, NULL);
 	}
+}
+
+static inline int
+abd_subpage_cache_index(const size_t size)
+{
+	const int idx = size >> SPA_MINBLOCKSHIFT;
+
+	if ((size % SPA_MINBLOCKSIZE) == 0)
+		return (idx - 1);
+	else
+		return (idx);
+}
+
+static inline uint_t
+abd_subpage_enclosing_size(const int i)
+{
+	return (SPA_MINBLOCKSIZE * (i + 1));
 }
 
 void
 abd_alloc_chunks(abd_t *abd, size_t size)
 {
-	size_t n = abd_chunkcnt_for_bytes(size);
-	for (int i = 0; i < n; i++) {
-		void *c = kmem_cache_alloc(abd_chunk_cache, KM_SLEEP);
-		ABD_SCATTER(abd).abd_chunks[i] = c;
+	VERIFY3U(size, >, 0);
+	if (size <= (zfs_abd_chunk_size - SPA_MINBLOCKSIZE)) {
+		const int i = abd_subpage_cache_index(size);
+		const uint_t s = abd_subpage_enclosing_size(i);
+		VERIFY3U(s, >=, size);
+		VERIFY3U(s, <, zfs_abd_chunk_size);
+		void *c = kmem_cache_alloc(abd_subpage_cache[i], KM_SLEEP);
+		ABD_SCATTER(abd).abd_chunks[0] = c;
+		ABD_SCATTER(abd).abd_chunk_size = s;
+	} else {
+		const size_t n = abd_chunkcnt_for_bytes(size);
+
+		for (int i = 0; i < n; i++) {
+			void *c = kmem_cache_alloc(abd_chunk_cache, KM_SLEEP);
+			ABD_SCATTER(abd).abd_chunks[i] = c;
+		}
+		ABD_SCATTER(abd).abd_chunk_size = zfs_abd_chunk_size;
 	}
-	ABD_SCATTER(abd).abd_chunk_size = zfs_abd_chunk_size;
 }
 
 void
 abd_free_chunks(abd_t *abd)
 {
-	size_t n = abd_scatter_chunkcnt(abd);
-	for (int i = 0; i < n; i++) {
-		abd_free_chunk(ABD_SCATTER(abd).abd_chunks[i]);
+	const uint_t abd_cs = ABD_SCATTER(abd).abd_chunk_size;
+
+	if (abd_cs < zfs_abd_chunk_size) {
+		VERIFY3U(abd->abd_size, <, zfs_abd_chunk_size);
+		VERIFY0(abd_cs % SPA_MINBLOCKSIZE);
+
+		const int idx = abd_subpage_cache_index(abd_cs);
+
+		kmem_cache_free(abd_subpage_cache[idx],
+		    ABD_SCATTER(abd).abd_chunks[0]);
+	} else {
+		const size_t n = abd_scatter_chunkcnt(abd);
+		for (int i = 0; i < n; i++) {
+			abd_free_chunk(ABD_SCATTER(abd).abd_chunks[i]);
+		}
 	}
 }
 
@@ -260,9 +343,28 @@ abd_free_zero_scatter(void)
 void
 abd_init(void)
 {
+	/* check if we guessed ABD_PGSIZE correctly */
+	ASSERT3U(ABD_PGSIZE, ==, PAGE_SIZE);
+
+#ifdef DEBUG
+	/*
+	 * KMF_BUFTAG | KMF_LITE on the abd kmem_caches causes them to waste
+	 * up to 50% of their memory for redzone.  Even in DEBUG builds this
+	 * therefore should be KMC_NOTOUCH unless there are concerns about
+	 * overruns, UAFs, etc involving abd chunks or subpage chunks.
+	 *
+	 * Additionally these KMF_
+	 * flags require the definitions from <sys/kmem_impl.h>
+	 */
+	// const int cflags = KMF_BUFTAG | KMF_LITE;
+	const int cflags = KMC_NOTOUCH;
+#else
+	const int cflags = KMC_NOTOUCH;
+#endif
+
 	abd_chunk_cache = kmem_cache_create("abd_chunk", zfs_abd_chunk_size,
-	    MIN(PAGE_SIZE, 4096),
-	    NULL, NULL, NULL, NULL, abd_arena, KMC_NOTOUCH);
+	    ABD_PGSIZE,
+	    NULL, NULL, NULL, NULL, abd_arena, cflags);
 
 	abd_ksp = kstat_create("zfs", 0, "abdstats", "misc", KSTAT_TYPE_NAMED,
 	    sizeof (abd_stats) / sizeof (kstat_named_t), KSTAT_FLAG_VIRTUAL);
@@ -272,11 +374,48 @@ abd_init(void)
 	}
 
 	abd_alloc_zero_scatter();
+
+	/*
+	 * Check at compile time that SPA_MINBLOCKSIZE is 512, because we want
+	 * to build sub-page-size linear ABD kmem caches at multiples of
+	 * SPA_MINBLOCKSIZE.  If SPA_MINBLOCKSIZE ever changes, a different
+	 * layout should be calculated at runtime.
+	 *
+	 * See also the assertions above the definition of abd_subpbage_cache.
+	 */
+
+	_Static_assert(SPA_MINBLOCKSIZE == 512,
+	    "unexpected SPA_MINBLOCKSIZE != 512");
+
+	const int step_size = SPA_MINBLOCKSIZE;
+	for (int bytes = step_size; bytes < ABD_PGSIZE; bytes += step_size) {
+		char name[36];
+
+		(void) snprintf(name, sizeof (name),
+		    "abd_subpage_%lu", (ulong_t)bytes);
+
+		const int index = (bytes >> SPA_MINBLOCKSHIFT) - 1;
+		VERIFY3U(index, >=, 0);
+		VERIFY3U(index, <, ABD_PGSIZE >> SPA_MINBLOCKSHIFT);
+
+		abd_subpage_cache[index] =
+		    kmem_cache_create(name, bytes, 512,
+		    NULL, NULL, NULL, NULL, abd_subpage_arena, cflags);
+
+		VERIFY3P(abd_subpage_cache[index], !=, NULL);
+	}
 }
 
 void
 abd_fini(void)
 {
+	const int step_size = SPA_MINBLOCKSIZE;
+	for (int bytes = step_size; bytes < ABD_PGSIZE; bytes += step_size) {
+		const int index = (bytes >> SPA_MINBLOCKSHIFT) - 1;
+		kmem_cache_destroy(abd_subpage_cache[index]);
+		abd_subpage_cache[index] = NULL;
+	}
+
 	abd_free_zero_scatter();
 
 	if (abd_ksp != NULL) {
@@ -314,27 +453,64 @@ abd_alloc_for_io(size_t size, boolean_t is_metadata)
 	return (abd_alloc_linear(size, is_metadata));
 }
 
+
+/*
+ * return an ABD structure that peers into source ABD sabd.  The returned ABD
+ * may be new, or the one supplied as abd.  abd and sabd must point to one or
+ * more zfs_abd_chunk_size (ABD_PGSIZE) chunks, or point to one and exactly one
+ * smaller chunk.
+ *
+ * The [off, off+size] range must be found within (and thus
+ * fit within) the source ABD.
+ */
+
 abd_t *
 abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off, size_t size)
 {
 	abd_verify(sabd);
 	VERIFY3U(off, <=, sabd->abd_size);
 
-	size_t new_offset = ABD_SCATTER(sabd).abd_offset + off;
+	const uint_t sabd_chunksz = ABD_SCATTER(sabd).abd_chunk_size;
+
+	const size_t new_offset = ABD_SCATTER(sabd).abd_offset + off;
+
+	/* subpage ABD range checking */
+	if (sabd_chunksz != zfs_abd_chunk_size) {
+		/*  off+size must fit in 1 chunk */
+		VERIFY3U(off + size, <=, sabd_chunksz);
+		/* new_offset must be in bounds of 1 chunk */
+		VERIFY3U(new_offset, <=, sabd_chunksz);
+		/* new_offset + size must be in bounds of 1 chunk */
+		VERIFY3U(new_offset + size, <=, sabd_chunksz);
+	}
 
 	/*
 	 * chunkcnt is abd_chunkcnt_for_bytes(size), which rounds
 	 * up to the nearest chunk, but we also must take care
 	 * of the offset *in the leading chunk*
 	 */
-	size_t chunkcnt = abd_chunkcnt_for_bytes(
-	    (new_offset % zfs_abd_chunk_size) + size);
+	const size_t chunkcnt = (sabd_chunksz != zfs_abd_chunk_size)
+	    ? 1
+	    : abd_chunkcnt_for_bytes((new_offset % sabd_chunksz) + size);
 
+	/* sanity checks on chunkcnt */
 	VERIFY3U(chunkcnt, <=, abd_scatter_chunkcnt(sabd));
+	VERIFY3U(chunkcnt, >, 0);
+
+	/* non-subpage sanity checking */
+	if (chunkcnt > 1) {
+		/* compare with legacy calculation of chunkcnt */
+		VERIFY3U(chunkcnt, ==, abd_chunkcnt_for_bytes(
+		    (new_offset % zfs_abd_chunk_size) + size));
+		/* EITHER subpage chunk (singular) or std chunks */
+		VERIFY3U(sabd_chunksz, ==, zfs_abd_chunk_size);
+	}
 
 	/*
-	 * If an abd struct is provided, it is only the minimum size.  If we
-	 * need additional chunks, we need to allocate a new struct.
+	 * If an abd struct is provided, it is only the minimum size (and
+	 * almost certainly provided as an abd_t embedded in a larger
+	 * structure). If we need additional chunks, we need to allocate a
+	 * new struct.
 	 */
 	if (abd != NULL &&
 	    offsetof(abd_t, abd_u.abd_scatter.abd_chunks[chunkcnt]) >
@@ -343,7 +519,7 @@ abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off, size_t size)
 	}
 
 	if (abd == NULL)
-		abd = abd_alloc_struct(chunkcnt * zfs_abd_chunk_size);
+		abd = abd_alloc_struct(chunkcnt * sabd_chunksz);
 
 	/*
 	 * Even if this buf is filesystem metadata, we only track that
@@ -351,13 +527,24 @@ abd_get_offset_scatter(abd_t *abd, abd_t *sabd, size_t off, size_t size)
 	 * this case. Therefore, we don't ever use ABD_FLAG_META here.
 	 */
 
-	ABD_SCATTER(abd).abd_offset = new_offset % zfs_abd_chunk_size;
-	ABD_SCATTER(abd).abd_chunk_size = zfs_abd_chunk_size;
+	/* update offset, and sanity check it */
+	ABD_SCATTER(abd).abd_offset = new_offset % sabd_chunksz;
+
+	VERIFY3U(ABD_SCATTER(abd).abd_offset, <, sabd_chunksz);
+	VERIFY3U(ABD_SCATTER(abd).abd_offset + size, <=,
+	    chunkcnt * sabd_chunksz);
+
+	ABD_SCATTER(abd).abd_chunk_size = sabd_chunksz;
+
+	if (chunkcnt > 1) {
+		VERIFY3U(ABD_SCATTER(sabd).abd_chunk_size, ==,
+		    zfs_abd_chunk_size);
+	}
 
 	/* Copy the scatterlist starting at the correct offset */
 	(void) memcpy(&ABD_SCATTER(abd).abd_chunks,
 	    &ABD_SCATTER(sabd).abd_chunks[new_offset /
-	    zfs_abd_chunk_size],
+	    sabd_chunksz],
 	    chunkcnt * sizeof (void *));
 
 	return (abd);
@@ -368,15 +555,16 @@ abd_iter_scatter_chunk_offset(struct abd_iter *aiter)
 {
 	ASSERT(!abd_is_linear(aiter->iter_abd));
 	return ((ABD_SCATTER(aiter->iter_abd).abd_offset +
-	    aiter->iter_pos) % zfs_abd_chunk_size);
+	    aiter->iter_pos) %
+	    ABD_SCATTER(aiter->iter_abd).abd_chunk_size);
 }
 
 static inline size_t
 abd_iter_scatter_chunk_index(struct abd_iter *aiter)
 {
 	ASSERT(!abd_is_linear(aiter->iter_abd));
-	return ((ABD_SCATTER(aiter->iter_abd).abd_offset +
-	    aiter->iter_pos) / zfs_abd_chunk_size);
+	return ((ABD_SCATTER(aiter->iter_abd).abd_offset + aiter->iter_pos)
+	    / ABD_SCATTER(aiter->iter_abd).abd_chunk_size);
 }
 
 /*
@@ -434,9 +622,30 @@ abd_iter_map(struct abd_iter *aiter)
 	ASSERT3P(aiter->iter_mapaddr, ==, NULL);
 	ASSERT0(aiter->iter_mapsize);
 
+#if 0
 	/* Panic if someone has changed zfs_abd_chunk_size */
+
 	IMPLY(!abd_is_linear(aiter->iter_abd), zfs_abd_chunk_size ==
 	    ABD_SCATTER(aiter->iter_abd).abd_chunk_size);
+#else
+	/*
+	 * If scattered, VERIFY that we are using ABD_PGSIZE chunks, or we have
+	 * one and only one chunk of less than ABD_PGSIZE.
+	 */
+
+	if (!abd_is_linear(aiter->iter_abd)) {
+		if (ABD_SCATTER(aiter->iter_abd).abd_chunk_size !=
+		    zfs_abd_chunk_size) {
+			VERIFY3U(
+			    ABD_SCATTER(aiter->iter_abd).abd_chunk_size,
+			    <, zfs_abd_chunk_size);
+			VERIFY3U(aiter->iter_abd->abd_size,
+			    <, zfs_abd_chunk_size);
+			VERIFY3U(aiter->iter_abd->abd_size,
+			    <=, ABD_SCATTER(aiter->iter_abd).abd_chunk_size);
+		}
+	}
+#endif
 
 	/* There's nothing left to iterate over, so do nothing */
 	if (abd_iter_at_end(aiter))
@@ -448,8 +657,12 @@ abd_iter_map(struct abd_iter *aiter)
 		paddr = ABD_LINEAR_BUF(aiter->iter_abd);
 	} else {
 		size_t index = abd_iter_scatter_chunk_index(aiter);
+		IMPLY(ABD_SCATTER(aiter->iter_abd).abd_chunk_size != ABD_PGSIZE,
+		    index == 0);
 		offset = abd_iter_scatter_chunk_offset(aiter);
-		aiter->iter_mapsize = MIN(zfs_abd_chunk_size - offset,
+		aiter->iter_mapsize = MIN(
+		    ABD_SCATTER(aiter->iter_abd).abd_chunk_size
+		    - offset,
 		    aiter->iter_abd->abd_size - aiter->iter_pos);
 		paddr = ABD_SCATTER(aiter->iter_abd).abd_chunks[index];
 	}
@@ -463,12 +676,10 @@ abd_iter_map(struct abd_iter *aiter)
 void
 abd_iter_unmap(struct abd_iter *aiter)
 {
-	/* There's nothing left to unmap, so do nothing */
-	if (abd_iter_at_end(aiter))
-		return;
-
-	ASSERT3P(aiter->iter_mapaddr, !=, NULL);
-	ASSERT3U(aiter->iter_mapsize, >, 0);
+	if (!abd_iter_at_end(aiter)) {
+		ASSERT3P(aiter->iter_mapaddr, !=, NULL);
+		ASSERT3U(aiter->iter_mapsize, >, 0);
+	}
 
 	aiter->iter_mapaddr = NULL;
 	aiter->iter_mapsize = 0;
@@ -478,4 +689,11 @@ void
 abd_cache_reap_now(void)
 {
 	kmem_cache_reap_now(abd_chunk_cache);
+
+	const int step_size = SPA_MINBLOCKSIZE;
+	for (int bytes = step_size; bytes < ABD_PGSIZE; bytes += step_size) {
+		const int index = (bytes >> SPA_MINBLOCKSHIFT) - 1;
+		kmem_cache_reap_now(abd_subpage_cache[index]);
+	}
+
 }

--- a/module/zfs/vdev_raidz_math_aarch64_neonx2.c
+++ b/module/zfs/vdev_raidz_math_aarch64_neonx2.c
@@ -210,6 +210,7 @@ DEFINE_GEN_METHODS(aarch64_neonx2);
  * If compiled with -O0, gcc doesn't do any stack frame coalescing
  * and -Wframe-larger-than=1024 is triggered in debug mode.
  */
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wframe-larger-than="
 DEFINE_REC_METHODS(aarch64_neonx2);
 #pragma GCC diagnostic pop


### PR DESCRIPTION
[done, ok] run in tester, also check running against ashift=9 raidz[23] 

[done, PAGE_SIZE is not a compile-time constant on ARM] revisit using PAGE_SIZE for ARM (rather than 4096 bytes) as default chunk size, in particular considering tail waste in the final chunk of a multi-chunk scatter ABD

[done, ok] Is tail waste high for ashift=9 even with 4k chunksize?  check this on my ginormous old ashift=9 vdev.

[NOTOUCH yes, keep VERIFYs for now because of forthcoming upstream abd work] Nerf / remove paranoid VERIFYs before landing, and switch to KMF_NOTOUCH in debug build.

Prior to this PR, abd_os.c's abd_size_alloc_linear() would make ABDs smaller than 4096 bytes be allocated as linear ABDs rather than use a whole 4096-byte chunk.    Linear ABDs are allocated from zio buffers (segregating small data and metadata), raising lifetime-vs-fragmentation concerns for the heap.

Also, let's take seriously the block comment above abd_alloc_linear() in module/zfs/abd.c : 

```
 * Allocate an ABD that must be linear, along with its own underlying data
 * buffer. Only use this when it would be very annoying to write your ABD
 * consumer with a scattered ABD.
 ```

The by-far-most-frequent reason a linear ABD is allocated is that abd_size_alloc_linear() returns B_TRUE.   So let's not do that.
 
This PR creates a subpage arena parented to the abd_cache arena, and several kmem_caches holding multiples of SPA_MINBLOCKSIZE bytes.   Small ABDs will now be scatter ABDs by default, and will hold a single chunk from one of these kmem_caches.


