### PR TITLE
Newer dmu pr

### DIFF
--- a/include/os/macos/zfs/sys/zvolIO.h
+++ b/include/os/macos/zfs/sys/zvolIO.h
@@ -37,14 +37,12 @@ extern "C" {
 #include <sys/zvol.h>
 #include <sys/zvol_impl.h>
 
-struct iomem {
-	IOMemoryDescriptor *buf;
-};
-
-uint64_t zvolIO_kit_read(struct iomem *iomem, uint64_t offset,
-    char *address, uint64_t len);
-uint64_t zvolIO_kit_write(struct iomem *iomem, uint64_t offset,
-    char *address, uint64_t len);
+extern size_t
+zvolIO_kit_read(const void *privptr, char *address, uint64_t offset,
+    uint64_t logical_offset, size_t len);
+extern size_t
+zvolIO_kit_write(const void *privptr, char *address, uint64_t offset,
+    uint64_t logical_offset, size_t len);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/os/macos/zfs/sys/zvolIO.h
+++ b/include/os/macos/zfs/sys/zvolIO.h
@@ -37,12 +37,8 @@ extern "C" {
 #include <sys/zvol.h>
 #include <sys/zvol_impl.h>
 
-extern size_t
-zvolIO_kit_read(const void *privptr, char *address, uint64_t offset,
-    uint64_t logical_offset, size_t len);
-extern size_t
-zvolIO_kit_write(const void *privptr, char *address, uint64_t offset,
-    uint64_t logical_offset, size_t len);
+extern size_t zvolIO_strategy(char *addr, uint64_t offset,
+    size_t len, zfs_uio_rw_t rw, const void *privptr);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/os/macos/zfs/sys/zvol_os.h
+++ b/include/os/macos/zfs/sys/zvol_os.h
@@ -28,7 +28,6 @@ extern "C" {
 /* struct wrapper for IOKit class */
 typedef struct zvol_iokit zvol_iokit_t;
 typedef struct zvol_state zvol_state_t;
-struct iomem;
 
 struct zvol_state_os {
 	dev_t	zvo_dev;	/* device id */
@@ -48,9 +47,9 @@ extern int zvol_os_read(dev_t dev, struct uio *uio, int p);
 extern int zvol_os_write(dev_t dev, struct uio *uio, int p);
 
 extern int zvol_os_read_zv(zvol_state_t *zv, uint64_t position,
-    uint64_t count, struct iomem *iomem);
+    uint64_t count, const void *iomem);
 extern int zvol_os_write_zv(zvol_state_t *zv, uint64_t position,
-    uint64_t count, struct iomem *iomem);
+    uint64_t count, const void *iomem);
 extern int zvol_os_unmap(zvol_state_t *zv, uint64_t off, uint64_t bytes);
 
 extern void zvol_os_strategy(struct buf *bp);

--- a/include/os/macos/zfs/sys/zvol_os.h
+++ b/include/os/macos/zfs/sys/zvol_os.h
@@ -46,10 +46,8 @@ extern int zvol_os_close(dev_t dev, int flag, int otyp, struct proc *p);
 extern int zvol_os_read(dev_t dev, struct uio *uio, int p);
 extern int zvol_os_write(dev_t dev, struct uio *uio, int p);
 
-extern int zvol_os_read_zv(zvol_state_t *zv, uint64_t position,
-    uint64_t count, const void *iomem);
-extern int zvol_os_write_zv(zvol_state_t *zv, uint64_t position,
-    uint64_t count, const void *iomem);
+extern int zvol_os_read_zv(zvol_state_t *zv, zfs_uio_t *uio);
+extern int zvol_os_write_zv(zvol_state_t *zv, zfs_uio_t *uio);
 extern int zvol_os_unmap(zvol_state_t *zv, uint64_t off, uint64_t bytes);
 
 extern void zvol_os_strategy(struct buf *bp);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -833,6 +833,10 @@ int dmu_free_long_object(objset_t *os, uint64_t object);
 #define	DMU_READ_PREFETCH	0 /* prefetch */
 #define	DMU_READ_NO_PREFETCH	1 /* don't prefetch */
 #define	DMU_READ_NO_DECRYPT	2 /* don't decrypt */
+
+typedef size_t (*dmu_io_func)(const void *privptr, char *addr,
+    uint64_t offset, uint64_t logical_offset, size_t len);
+
 int dmu_read(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	void *buf, uint32_t flags);
 int dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
@@ -853,6 +857,10 @@ int dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
 int dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
+int dmu_read_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
+    void *privptr, dmu_io_func func, uint32_t flags);
+int dmu_write_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
+    const void *privptr, dmu_io_func func, dmu_tx_t *tx);
 #endif
 struct arc_buf *dmu_request_arcbuf(dmu_buf_t *handle, int size);
 void dmu_return_arcbuf(struct arc_buf *buf);

--- a/include/sys/dmu.h
+++ b/include/sys/dmu.h
@@ -833,10 +833,6 @@ int dmu_free_long_object(objset_t *os, uint64_t object);
 #define	DMU_READ_PREFETCH	0 /* prefetch */
 #define	DMU_READ_NO_PREFETCH	1 /* don't prefetch */
 #define	DMU_READ_NO_DECRYPT	2 /* don't decrypt */
-
-typedef size_t (*dmu_io_func)(const void *privptr, char *addr,
-    uint64_t offset, uint64_t logical_offset, size_t len);
-
 int dmu_read(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	void *buf, uint32_t flags);
 int dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
@@ -857,10 +853,6 @@ int dmu_write_uio_dbuf(dmu_buf_t *zdb, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
 int dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size,
 	dmu_tx_t *tx);
-int dmu_read_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
-    void *privptr, dmu_io_func func, uint32_t flags);
-int dmu_write_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
-    const void *privptr, dmu_io_func func, dmu_tx_t *tx);
 #endif
 struct arc_buf *dmu_request_arcbuf(dmu_buf_t *handle, int size);
 void dmu_return_arcbuf(struct arc_buf *buf);

--- a/module/os/macos/spl/spl-uio.c
+++ b/module/os/macos/spl/spl-uio.c
@@ -49,6 +49,13 @@ zfs_uiomove_iov(void *p, size_t n, zfs_uio_rw_t rw, zfs_uio_t *uio)
 					bcopy(iov->iov_base + skip, (void *)p,
 					    cnt);
 				break;
+
+			case UIO_FUNCSPACE:
+				VERIFY3P(uio->uio_iofunc, !=, NULL);
+				cnt = uio->uio_iofunc(p, skip, cnt, rw,
+				    iov->iov_base);
+				break;
+
 			default:
 				VERIFY(0);
 				return (-1);

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -994,25 +994,11 @@ dmu_free_range(objset_t *os, uint64_t object, uint64_t offset,
 	return (0);
 }
 
-inline static size_t dmu_read_default(const void *buf, char *addr,
-    uint64_t offset, uint64_t logical_offset, size_t len)
-{
-	/* Deal with odd block sizes */
-	if (addr == NULL) {
-		bzero((char *)buf, len);
-		return (len);
-	}
-
-	(void) memcpy((char *)buf + logical_offset, (char *)addr, len);
-	return (len);
-}
-
 static int
 dmu_read_impl(dnode_t *dn, uint64_t offset, uint64_t size,
-    void *buf, dmu_io_func func, uint32_t flags)
+    void *buf, uint32_t flags)
 {
 	dmu_buf_t **dbp;
-	uint64_t logical_offset = 0ULL;
 	int numbufs, err = 0;
 
 	/*
@@ -1023,7 +1009,7 @@ dmu_read_impl(dnode_t *dn, uint64_t offset, uint64_t size,
 	if (dn->dn_maxblkid == 0) {
 		uint64_t newsz = offset > dn->dn_datablksz ? 0 :
 		    MIN(size, dn->dn_datablksz - offset);
-		(void) func((char *)buf + newsz, NULL, 0, 0, size - newsz);
+		bzero((char *)buf + newsz, size - newsz);
 		size = newsz;
 	}
 
@@ -1050,17 +1036,11 @@ dmu_read_impl(dnode_t *dn, uint64_t offset, uint64_t size,
 			bufoff = offset - db->db_offset;
 			tocpy = MIN(db->db_size - bufoff, size);
 
-			tocpy = func(buf, (char *)db->db_data + bufoff, offset,
-			    logical_offset, tocpy);
-
-			if (tocpy < 0) {
-				err = SET_ERROR(EIO);
-				break;
-			}
+			(void) memcpy(buf, (char *)db->db_data + bufoff, tocpy);
 
 			offset += tocpy;
 			size -= tocpy;
-			logical_offset += tocpy;
+			buf = (char *)buf + tocpy;
 		}
 		dmu_buf_rele_array(dbp, numbufs, FTAG);
 	}
@@ -1078,7 +1058,7 @@ dmu_read(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 	if (err != 0)
 		return (err);
 
-	err = dmu_read_impl(dn, offset, size, buf, dmu_read_default, flags);
+	err = dmu_read_impl(dn, offset, size, buf, flags);
 	dnode_rele(dn, FTAG);
 	return (err);
 }
@@ -1087,22 +1067,14 @@ int
 dmu_read_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size, void *buf,
     uint32_t flags)
 {
-	return (dmu_read_impl(dn, offset, size, buf, dmu_read_default, flags));
+	return (dmu_read_impl(dn, offset, size, buf, flags));
 }
 
-inline static size_t dmu_write_default(const void *buf, char *addr,
-    uint64_t offset, uint64_t logical_offset, size_t len)
-{
-	(void) memcpy((char *)addr, (char *)buf + logical_offset, len);
-	return (len);
-}
-
-static int
+static void
 dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
-    const void *buf, dmu_io_func func, dmu_tx_t *tx)
+    const void *buf, dmu_tx_t *tx)
 {
 	int i;
-	uint64_t logical_offset = 0ULL;
 
 	for (i = 0; i < numbufs; i++) {
 		uint64_t tocpy;
@@ -1121,20 +1093,15 @@ dmu_write_impl(dmu_buf_t **dbp, int numbufs, uint64_t offset, uint64_t size,
 		else
 			dmu_buf_will_dirty(db, tx);
 
-		tocpy = func(buf, (char *)db->db_data + bufoff, offset,
-		    logical_offset, tocpy);
-
-		if (tocpy < 0)
-			return (SET_ERROR(EIO));
+		(void) memcpy((char *)db->db_data + bufoff, buf, tocpy);
 
 		if (tocpy == db->db_size)
 			dmu_buf_fill_done(db, tx);
 
 		offset += tocpy;
 		size -= tocpy;
-		logical_offset += tocpy;
+		buf = (char *)buf + tocpy;
 	}
-	return (0);
 }
 
 void
@@ -1149,8 +1116,7 @@ dmu_write(objset_t *os, uint64_t object, uint64_t offset, uint64_t size,
 
 	VERIFY0(dmu_buf_hold_array(os, object, offset, size,
 	    FALSE, FTAG, &numbufs, &dbp));
-	(void) dmu_write_impl(dbp, numbufs, offset, size, buf,
-	    dmu_write_default, tx);
+	dmu_write_impl(dbp, numbufs, offset, size, buf, tx);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
 
@@ -1169,8 +1135,7 @@ dmu_write_by_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
 
 	VERIFY0(dmu_buf_hold_array_by_dnode(dn, offset, size,
 	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH));
-	(void) dmu_write_impl(dbp, numbufs, offset, size, buf,
-	    dmu_write_default, tx);
+	dmu_write_impl(dbp, numbufs, offset, size, buf, tx);
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 }
 
@@ -1267,36 +1232,64 @@ dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size)
 	return (err);
 }
 
-/*
- * Issue IO with callout to function 'func'.
- * int func(void *privptr, char *address, uint64_t offset, uint64_t len);
- * return number of bytes processed (hopefully 'len' amount). negative
- * return for failure abort.
- */
-int
-dmu_read_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
-    void *privptr, dmu_io_func func, uint32_t flags)
-{
-	return (dmu_read_impl(dn, offset, size, privptr, func, flags));
-}
+#ifdef __APPLE__
+struct iomem;
+
+extern uint64_t zvolIO_kit_read(struct iomem *iomem, uint64_t offset,
+    char *address, uint64_t len);
+
+extern uint64_t zvolIO_kit_write(struct iomem *iomem, uint64_t offset,
+    char *address, uint64_t len);
 
 int
-dmu_write_func_dnode(dnode_t *dn, uint64_t offset, uint64_t size,
-    const void *privptr, dmu_io_func func, dmu_tx_t *tx)
+dmu_read_iokit_dnode(dnode_t *dn, uint64_t *offset,
+    uint64_t position, uint64_t *size, struct iomem *iomem)
 {
+	int err;
+
+	if (*size == 0)
+		return (0);
+
 	dmu_buf_t **dbp;
-	int numbufs;
-	int err = 0;
+	int numbufs, i;
 
-	if (size == 0)
+	/*
+	 * NB: we could do this block-at-a-time, but it's nice
+	 * to be reading in parallel.
+	 */
+	err = dmu_buf_hold_array_by_dnode(dn, (position+*offset), *size,
+	    TRUE, FTAG, &numbufs, &dbp, 0);
+	if (err)
 		return (err);
 
-	VERIFY0(dmu_buf_hold_array_by_dnode(dn, offset, size,
-	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH));
-	err = dmu_write_impl(dbp, numbufs, offset, size, privptr, func, tx);
+	for (i = 0; i < numbufs; i++) {
+		uint64_t tocpy;
+		int64_t bufoff;
+		dmu_buf_t *db = dbp[i];
+		uint64_t done;
+
+		ASSERT(size > 0);
+
+		bufoff = (position+*offset) - db->db_offset;
+		tocpy = MIN(db->db_size - bufoff, *size);
+
+		done = zvolIO_kit_read(iomem,
+		    *offset,
+		    (char *)db->db_data + bufoff,
+		    tocpy);
+
+		if (!done) {
+			err = EIO;
+			break;
+		}
+		*size -= done;
+		*offset += done;
+	}
+
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 	return (err);
 }
+#endif /* APPLE */
 
 /*
  * Read 'size' bytes into the uio buffer.
@@ -1401,6 +1394,61 @@ dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size, dmu_tx_t *tx)
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 	return (err);
 }
+
+#ifdef __APPLE__
+int
+dmu_write_iokit_dnode(dnode_t *dn, uint64_t *offset, uint64_t position,
+    uint64_t *size, struct iomem *iomem, dmu_tx_t *tx)
+{
+	dmu_buf_t **dbp;
+	int numbufs;
+	int err = 0;
+	int i;
+
+	err = dmu_buf_hold_array_by_dnode(dn, *offset+position, *size,
+	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH);
+	if (err)
+		return (err);
+
+	while (*size > 0) {
+
+		for (i = 0; i < numbufs; i++) {
+			int tocpy;
+			int bufoff;
+			uint64_t done;
+			dmu_buf_t *db = dbp[i];
+
+			ASSERT(size > 0);
+
+			bufoff = (position + *offset) - db->db_offset;
+			tocpy = (int)MIN(db->db_size - bufoff, *size);
+
+			ASSERT(i == 0 || i == numbufs-1 ||
+			    tocpy == db->db_size);
+
+			if (tocpy == db->db_size)
+				dmu_buf_will_fill(db, tx);
+			else
+				dmu_buf_will_dirty(db, tx);
+
+			done = zvolIO_kit_write(iomem,
+			    *offset,
+			    (char *)db->db_data + bufoff,
+			    tocpy);
+
+			if (tocpy == db->db_size)
+				dmu_buf_fill_done(db, tx);
+			if (done > 0) {
+				*offset += done;
+				*size -= done;
+			}
+		}
+	}
+
+	dmu_buf_rele_array(dbp, numbufs, FTAG);
+	return (err);
+}
+#endif /* APPLE */
 
 /*
  * Write 'size' bytes from the uio buffer.

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1232,65 +1232,6 @@ dmu_read_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size)
 	return (err);
 }
 
-#ifdef __APPLE__
-struct iomem;
-
-extern uint64_t zvolIO_kit_read(struct iomem *iomem, uint64_t offset,
-    char *address, uint64_t len);
-
-extern uint64_t zvolIO_kit_write(struct iomem *iomem, uint64_t offset,
-    char *address, uint64_t len);
-
-int
-dmu_read_iokit_dnode(dnode_t *dn, uint64_t *offset,
-    uint64_t position, uint64_t *size, struct iomem *iomem)
-{
-	int err;
-
-	if (*size == 0)
-		return (0);
-
-	dmu_buf_t **dbp;
-	int numbufs, i;
-
-	/*
-	 * NB: we could do this block-at-a-time, but it's nice
-	 * to be reading in parallel.
-	 */
-	err = dmu_buf_hold_array_by_dnode(dn, (position+*offset), *size,
-	    TRUE, FTAG, &numbufs, &dbp, 0);
-	if (err)
-		return (err);
-
-	for (i = 0; i < numbufs; i++) {
-		uint64_t tocpy;
-		int64_t bufoff;
-		dmu_buf_t *db = dbp[i];
-		uint64_t done;
-
-		ASSERT(size > 0);
-
-		bufoff = (position+*offset) - db->db_offset;
-		tocpy = MIN(db->db_size - bufoff, *size);
-
-		done = zvolIO_kit_read(iomem,
-		    *offset,
-		    (char *)db->db_data + bufoff,
-		    tocpy);
-
-		if (!done) {
-			err = EIO;
-			break;
-		}
-		*size -= done;
-		*offset += done;
-	}
-
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
-	return (err);
-}
-#endif /* APPLE */
-
 /*
  * Read 'size' bytes into the uio buffer.
  * From object zdb->db_object.
@@ -1394,61 +1335,6 @@ dmu_write_uio_dnode(dnode_t *dn, zfs_uio_t *uio, uint64_t size, dmu_tx_t *tx)
 	dmu_buf_rele_array(dbp, numbufs, FTAG);
 	return (err);
 }
-
-#ifdef __APPLE__
-int
-dmu_write_iokit_dnode(dnode_t *dn, uint64_t *offset, uint64_t position,
-    uint64_t *size, struct iomem *iomem, dmu_tx_t *tx)
-{
-	dmu_buf_t **dbp;
-	int numbufs;
-	int err = 0;
-	int i;
-
-	err = dmu_buf_hold_array_by_dnode(dn, *offset+position, *size,
-	    FALSE, FTAG, &numbufs, &dbp, DMU_READ_PREFETCH);
-	if (err)
-		return (err);
-
-	while (*size > 0) {
-
-		for (i = 0; i < numbufs; i++) {
-			int tocpy;
-			int bufoff;
-			uint64_t done;
-			dmu_buf_t *db = dbp[i];
-
-			ASSERT(size > 0);
-
-			bufoff = (position + *offset) - db->db_offset;
-			tocpy = (int)MIN(db->db_size - bufoff, *size);
-
-			ASSERT(i == 0 || i == numbufs-1 ||
-			    tocpy == db->db_size);
-
-			if (tocpy == db->db_size)
-				dmu_buf_will_fill(db, tx);
-			else
-				dmu_buf_will_dirty(db, tx);
-
-			done = zvolIO_kit_write(iomem,
-			    *offset,
-			    (char *)db->db_data + bufoff,
-			    tocpy);
-
-			if (tocpy == db->db_size)
-				dmu_buf_fill_done(db, tx);
-			if (done > 0) {
-				*offset += done;
-				*size -= done;
-			}
-		}
-	}
-
-	dmu_buf_rele_array(dbp, numbufs, FTAG);
-	return (err);
-}
-#endif /* APPLE */
 
 /*
  * Write 'size' bytes from the uio buffer.


### PR DESCRIPTION
Ditch all changes to upstream.

Add new uio type.

Make zvol_os IO functions be same as upstream, calling dmu_read_dnode_uio() (and write).

Setup uio in special IOkit way, with iofunc callback.

Update spl-uio to handle new type. Instead of memcpy/bcopy data, call iofunc callback.

zvolIO.cpp to have iofunc callback function `zvolIO_strategy()` - calls the iomem->writeBytes (readBytes) as appropriate.



