### PR TITLE
use -thingie and no HAVE_LARGE_STACKS for great justice!

### DIFF
--- a/module/os/macos/spl/Makefile.am
+++ b/module/os/macos/spl/Makefile.am
@@ -7,6 +7,8 @@ libspl_la_CPPFLAGS= \
 	-nostdinc \
 	-mkernel \
 	-fno-builtin-printf \
+	-Wframe-larger-than=400 \
+	-finline-hint-functions \
 	-D_KERNEL \
 	-DKERNEL \
 	-DKERNEL_PRIVATE \

--- a/module/os/macos/zfs/Makefile.am
+++ b/module/os/macos/zfs/Makefile.am
@@ -16,6 +16,7 @@ zfs_CPPFLAGS = \
 	-DKERNEL \
 	-DKERNEL_PRIVATE \
 	-DDRIVER_PRIVATE \
+	-UHAVE_LARGE_STACKS \
 	-DNAMEDSTREAMS=1 \
 	-D__DARWIN_64_BIT_INO_T=1 \
 	-DAPPLE \
@@ -34,9 +35,11 @@ zfs_CPPFLAGS += @KERNEL_DEBUG_CPPFLAGS@
 
 zfs_CFLAGS = -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-conditional-uninitialized
 zfs_CFLAGS += -Wno-shadow -Wno-implicit-int-conversion
+zfs_CFLAGS += -finline-hint-functions
 
 zfs_CXXFLAGS = -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-conditional-uninitialized
 zfs_CXXFLAGS += -std=gnu++11
+zfs_CXXFLAGS += -finline-hint-functions
 
 zfs_LDFLAGS = \
 	-Xlinker \


### PR DESCRIPTION
We appear to have a stack overflow problem.

HAVE_LARGE_STACKS is default.  It drives the decision
about whether (HAVE) or not (!HAVE) to do txg sync context
(frequent) and pool initialization (much less frequent)
zio work in the same thread as the present __zio_execute,
or whether it should be pushed to the head of the line of
zios to be serviced asynchronously by another thread.

Let's not define HAVE_LARGE_STACKS when building the kext
for macOS.

Clang's -finline-hint-functions inlines all threads
explicitly hinted as inline "static inline foo(...) { }"
or equipped with an __attribute__((always_inline)), but
does not inline other functions, even if they are static.

Clang & LLVM's inlining bumps the stack frame size to
include automatic variables in the inlined functions,
growing the stack even for invocations where the inlined
function will not be reached.  This has led to large stack
frames in recursively called functions, notably
dsl_scan_visitbp, which was dealt with by removing the
always inline attribute.

Globally enabling -finline-hint-functions reduces the
number of inlined functions enough to make un-inlining
such functions, while still inlining obvious
wins (e.g. tiny frequently called from all over the source
tree functions such as atomic_add_64_nv()).

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
