### PR TITLE
A race to thread_call_enter1() could deadlock

### DIFF
--- a/include/os/macos/spl/sys/vmem_impl.h
+++ b/include/os/macos/spl/sys/vmem_impl.h
@@ -152,9 +152,10 @@ struct vmem {
 	void		*vm_qcache[VMEM_NQCACHE_MAX]; /* quantum caches */
 	vmem_freelist_t	vm_freelist[VMEM_FREELISTS + 1]; /* power-of-2 flists */
 	vmem_kstat_t	vm_kstat;	/* kstat data */
-	thread_call_t	vm_stack_call_thread;
-	kmutex_t	vm_stack_lock;
+	thread_call_t	vm_stack_call_thread; /* worker thread for vmem_alloc */
+	kmutex_t	vm_stack_lock; /* synchronize with worker thread */
 	kcondvar_t	vm_stack_cv;
+	_Atomic bool	vm_cb_busy; /* gateway before thread_call_enter1() */
 };
 
 #ifdef	__cplusplus


### PR DESCRIPTION
If multiple concurrent deep-stack allocation requests race
to vmem_alloc(), the "winner" of the race could be
cancelled by one of the other racers, and so the cancelled
"winner" would never see the done flag, and would spend
the rest of eternity stuck in a cv_wait() loop, hanging
the thread that wanted memory.

This commit uses a per-arena busy flag to block the later
racers from reaching thread_call_enter1() until the
race-winner's in-worker-thread memory allocation is
complete.

Additionally, the worker does less work updating stats,
and only takes a mutex around the cv_signal(). The parent
also checks for lost and duplicate cv_signals() error
conditions.

https://github.com/openzfsonosx/openzfs/issues/90

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
