### PR TITLE
iokit sync

### DIFF
--- a/module/os/macos/spl/spl-taskq.c
+++ b/module/os/macos/spl/spl-taskq.c
@@ -1684,7 +1684,10 @@ taskq_empty(taskq_t *tq)
 int
 taskq_empty_ent(taskq_ent_t *t)
 {
-	return (IS_EMPTY(*t));
+	if (t->tqent_prev == NULL && t->tqent_next == NULL)
+		return (TRUE);
+	else
+		return (IS_EMPTY(*t));
 }
 
 /*

--- a/module/os/macos/zfs/ldi_iokit.cpp
+++ b/module/os/macos/zfs/ldi_iokit.cpp
@@ -423,17 +423,19 @@ handle_sync_iokit(struct ldi_handle *lhp)
 
 #if defined(MAC_OS_X_VERSION_10_11) &&        \
 	(MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11)
+	/* from module/os/macos/zfs/zfs_vfsops.c */
+	extern uint64_t zfs_vfs_sync_paranoia;
 	/* Issue device sync */
-	if (LH_MEDIA(lhp)->synchronize(LH_CLIENT(lhp), 0, 0, kIOStorageSynchronizeOptionBarrier) !=
-	    kIOReturnSuccess) {
-		printf("%s %s\n", __func__,
-		    "IOMedia synchronizeCache (with write barrier) failed\n");
-		if (LH_MEDIA(lhp)->synchronize(LH_CLIENT(lhp), 0, 0, 0) !=
-		    kIOReturnSuccess) {
-			printf("%s %s\n", __func__,
-			    "IOMedia synchronizeCache (standard) failed\n");
-			return (ENOTSUP);
-		}
+	IOStorageSynchronizeOptions synctype = (zfs_vfs_sync_paranoia != 0)
+	    ? kIOStorageSynchronizeOptionNone
+	    : kIOStorageSynchronizeOptionBarrier;
+	IOReturn ret = LH_MEDIA(lhp)->synchronize(LH_CLIENT(lhp),
+	    0, 0, synctype);
+	if (ret !=  kIOReturnSuccess) {
+		printf("%s %s %d %s\n", __func__,
+		    "IOMedia synchronizeCache (with write barrier) failed",
+		    ret, "(see IOReturn.h)\n");
+		return (ENOTSUP);
 	}
 #else
 	/* Issue device sync */


### PR DESCRIPTION
- smd: fix taskq_empty_ent
- handle_sync_iokit: don't reuse lhp on failure, and allow paranoia

The handle_sync_iokit commit needs @me eyeballs on what should be passed
upwards in the event of failure, and whether recovery can be done cleverly in
some caller.
