### PR TITLE
WIP : Do more syncing when kstat.zfs.darwin.tunable.use_system_sync != 0

### DIFF
--- a/module/os/macos/spl/spl-taskq.c
+++ b/module/os/macos/spl/spl-taskq.c
@@ -1684,7 +1684,10 @@ taskq_empty(taskq_t *tq)
 int
 taskq_empty_ent(taskq_ent_t *t)
 {
-	return (IS_EMPTY(*t));
+	if (t->tqent_prev == NULL && t->tqent_next == NULL)
+		return (TRUE);
+	else
+		return (IS_EMPTY(*t));
 }
 
 /*

--- a/module/os/macos/zfs/ldi_iokit.cpp
+++ b/module/os/macos/zfs/ldi_iokit.cpp
@@ -423,17 +423,19 @@ handle_sync_iokit(struct ldi_handle *lhp)
 
 #if defined(MAC_OS_X_VERSION_10_11) &&        \
 	(MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_11)
+	/* from module/os/macos/zfs/zfs_vfsops.c */
+	extern uint64_t zfs_vfs_sync_paranoia;
 	/* Issue device sync */
-	if (LH_MEDIA(lhp)->synchronize(LH_CLIENT(lhp), 0, 0, kIOStorageSynchronizeOptionBarrier) !=
-	    kIOReturnSuccess) {
-		printf("%s %s\n", __func__,
-		    "IOMedia synchronizeCache (with write barrier) failed\n");
-		if (LH_MEDIA(lhp)->synchronize(LH_CLIENT(lhp), 0, 0, 0) !=
-		    kIOReturnSuccess) {
-			printf("%s %s\n", __func__,
-			    "IOMedia synchronizeCache (standard) failed\n");
-			return (ENOTSUP);
-		}
+	IOStorageSynchronizeOptions synctype = (zfs_vfs_sync_paranoia != 0)
+	    ? kIOStorageSynchronizeOptionNone
+	    : kIOStorageSynchronizeOptionBarrier;
+	IOReturn ret = LH_MEDIA(lhp)->synchronize(LH_CLIENT(lhp),
+	    0, 0, synctype);
+	if (ret !=  kIOReturnSuccess) {
+		printf("%s %s %d %s\n", __func__,
+		    "IOMedia synchronizeCache (with write barrier) failed",
+		    ret, "(see IOReturn.h)\n");
+		return (ENOTSUP);
 	}
 #else
 	/* Issue device sync */

--- a/module/os/macos/zfs/zfs_vfsops.c
+++ b/module/os/macos/zfs/zfs_vfsops.c
@@ -129,7 +129,7 @@ zfs_is_readonly(zfsvfs_t *zfsvfs)
  * syncs. (As per illumos) Unfortunately, we can not tell the difference
  * of when users run "sync" by hand. Sync is called on umount though.
  */
-uint64_t zfs_vfs_sync_paranoia = 0;
+uint64_t zfs_vfs_sync_paranoia = 1;
 
 int
 zfs_vfs_sync(struct mount *vfsp, __unused int waitfor,

--- a/tests/zfs-tests/cmd/librt/mach_gettime.c
+++ b/tests/zfs-tests/cmd/librt/mach_gettime.c
@@ -12,6 +12,8 @@
 #include <mach/clock.h>
 #include <mach/mach_time.h>
 
+void gettime_dummy(void);
+
 extern int
 clock_gettime(clock_id_t clock_id, struct timespec *tp);
 


### PR DESCRIPTION
1. Optionally set B_FUA on ZIO_PRIORITY_SYNC_WRITEs, which is uses for label and zil writes
2. Optionally issue a full sync rather than a barrier sync
3. Avoid a panic if a device goes offline during a full sync or barrier sync; higher layers in o3x will fault the affected device
4. Tidy taskq_empty_ent, eliminating a source of DEBUG logspam

Open questions:

1. Default to "paranoia"?  With reasonably current Macs, performance hit may be worth the safety.
2. Tidy naming of the tunable, maybe split tunable into 3 parts (barrier vs full; FUA vs no FUA; and bail out early from zfs_vfs_sync() or not).
3. A fourth option: do zfs_vfs_sync() except for spa_sync_allpools()

On  a busy multipool system with a mix of spinnydisks-alone, spinnydisks+SSD-slogs, and SSDs-alone, doing all the sync (except not-yet-tested B_FUA) does not hurt performance in practice.

Maybe-todo, maybe kick to future: look into zvols in the sync=standard case.